### PR TITLE
remove dependency on default.rb to load library

### DIFF
--- a/libraries/config_option.rb
+++ b/libraries/config_option.rb
@@ -9,3 +9,6 @@ module Extensions
 
   end
 end
+
+# load template extensions
+Erubis::Context.send(:include, Extensions::Templates)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,3 @@
-# load template extensions, look under libraries/ for more informations
-Erubis::Context.send(:include, Extensions::Templates)
-
 version = node.graylog2[:major_version]
 
 if platform_family?('rhel')


### PR DESCRIPTION
For security reasons we need to house RPMs locally and as such do not want to call the default recipe. This change is to enable specific recipes to be called individually and still ensure the template library is loaded.