### PR TITLE
Fix appender when node.graylog2[:web][:gelf_log][:host] is nil (default)

### DIFF
--- a/templates/default/graylog.web.conf.erb
+++ b/templates/default/graylog.web.conf.erb
@@ -26,7 +26,9 @@
 <%= config_option 'application.context', node.graylog2[:web][:context] -%>
 
 # Gelf Logging
+<% unless node.graylog2[:web][:gelf_log][:host].nil? -%>
 <%= config_option 'graylog2.appender.host', "\"#{node.graylog2[:web][:gelf_log][:host]}\"" -%>
+<% end -%>
 <%= config_option 'graylog2.appender.sourcehost', node.graylog2[:web][:gelf_log][:source] -%>
 <%= config_option 'graylog2.appender.send-access-log', node.graylog2[:web][:gelf_log][:send_access] -%>
 


### PR DESCRIPTION
I got the following error in `/var/log/graylog-web/application.log`

```
2015-02-20T11:21:00.894Z - [ERROR] - from org.graylog2.logback.appender.Graylog2Plugin in main
Malformed graylog2.appender.hosts entry . Please specify them as 'host:port'!
```

This fixes it.