### PR TITLE
[FIX] Use http_enabled from default attribtues

### DIFF
--- a/templates/default/graylog.server.conf.erb
+++ b/templates/default/graylog.server.conf.erb
@@ -40,7 +40,7 @@
 # Elasticsearch
 elasticsearch_node_master = false
 elasticsearch_node_data = false
-elasticsearch_http_enabled = false
+elasticsearch_http_enabled = <%= node.graylog2[:elasticsearch][:http_enabled] %>
 <%= config_option 'elasticsearch_config_file', node.graylog2[:elasticsearch][:config_file] -%>
 <%= config_option 'rotation_strategy', node.graylog2[:elasticsearch][:rotation_strategy] -%>
 <%= config_option 'elasticsearch_max_docs_per_index', node.graylog2[:elasticsearch][:max_docs_per_index] -%>

--- a/templates/default/graylog.server.elasticsearch.yml.erb
+++ b/templates/default/graylog.server.elasticsearch.yml.erb
@@ -11,10 +11,10 @@ node.data: false
 # you might need to bind to a certain IP address, do that here
 #network.host: 172.24.0.14
 # use a different port if you run multiple elasticsearch nodes on one machine
-transport.tcp.port: <%= node.graylog2[:elasticsearch][:transport_tcp_port] %> 
+transport.tcp.port: <%= node.graylog2[:elasticsearch][:transport_tcp_port] %>
 
 # we don't need to run the embedded HTTP server here
-http.enabled: false
+http.enabled: <%= node.graylog2[:elasticsearch][:http_enabled] %>
 
 # adapt these for discovery to work in your network! multicast can be tricky
 #discovery.zen.ping.multicast.address: 172.24.0.14


### PR DESCRIPTION
We noticed that you are not using the http_enabled variable that is defined in your default attributes. Assuming this should be used, this should enable it.