### PR TITLE
Deal with updated configuration in graylog packages on Ubuntu/Debian

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,6 +17,9 @@ package "graylog-server" do
   if platform?('debian')
     options "--force-yes"
   end
+  if node.platform_family == 'debian'
+    options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
+  end
   notifies :restart, 'service[graylog-server]', node.graylog2[:restart].to_sym
 end
 

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -9,6 +9,9 @@ package "graylog-web" do
   if platform?('debian')
     options "--force-yes"
   end
+  if node.platform_family == 'debian'
+    options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
+  end
   notifies :restart, 'service[graylog-web]', node.graylog2[:restart].to_sym
 end
 


### PR DESCRIPTION
The config files are generated by Chef anyway.

This is the same problem as in https://github.com/basho/riak-chef-cookbook/pull/142

I had this issue updating graylog-server from 1.0.0 to 1.0.1