### PR TITLE
Fix graylog2_token resource

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -102,7 +102,10 @@ default.graylog2[:elasticsearch][:disable_index_range_calculation]     = nil
 default.graylog2[:elasticsearch][:elasticsearch_store_timestamps_as_doc_values] = true
 
 # MongoDb
-default.graylog2[:mongodb][:uri] = 'mongodb://127.0.0.1:27017/graylog2'
+default.graylog2[:mongodb][:host] = '127.0.0.1'
+default.graylog2[:mongodb][:port] = '27017'
+default.graylog2[:mongodb][:database] = 'graylog2'
+default.graylog2[:mongodb][:uri] = "mongodb://#{default.graylog2[:mongodb][:host]}:#{default.graylog2[:mongodb][:port]}/#{default.graylog2[:mongodb][:database]}"
 default.graylog2[:mongodb][:max_connections] = 100
 default.graylog2[:mongodb][:threads_allowed_to_block_multiplier] = 5
 


### PR DESCRIPTION
[api_access recipe](https://github.com/Graylog2/graylog2-cookbook/blob/master/recipes/api_access.rb) not working after https://github.com/Graylog2/graylog2-cookbook/commit/80c318471fb0770958b514404ad8aecbaa695e17

It still uses old attributes in [providers/token.rb](https://github.com/Graylog2/graylog2-cookbook/blob/master/providers/token.rb#L5)

Tried to pass `graylog2[:mongodb][:uri]` to `Mongo::MongoClient.new()` but then I get:
```
Mongo::ConnectionFailure
------------------------
Failed to connect to a master node at mongodb://127.0.0.1:27017/graylog2:27017
```
Looks like those uri strings are not compatible with mongo gem.

Still not sure if it's a proper fix..

@mariussturm 