### PR TITLE
Fixed debian family force options in server, web, radio

### DIFF
--- a/recipes/radio.rb
+++ b/recipes/radio.rb
@@ -9,7 +9,7 @@ Chef::Mixin::DeepMerge.deep_merge!(secrets, node.override[:graylog2]) unless sec
 package 'graylog-radio' do
   action :install
   version node.graylog2[:radio][:version]
-  options '--force-yes' if platform?('debian')
+  options '--force-yes' if platform_family?('debian')
 end
 
 directory '/var/run/graylog-radio' do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -18,8 +18,7 @@ end
 package 'graylog-server' do
   action :install
   version node.graylog2[:server][:version]
-  options '--force-yes' if platform?('debian')
-  options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"' if node.platform_family == 'debian'
+  options '--force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"' if platform_family?('debian')
   notifies :restart, 'service[graylog-server]', node.graylog2[:restart].to_sym
 end
 

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -10,8 +10,7 @@ Chef::Application.fatal!('No web secret set, either set it via an attribute or i
 package 'graylog-web' do
   action :install
   version node.graylog2[:web][:version]
-  options '--force-yes' if platform?('debian')
-  options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"' if node.platform_family == 'debian'
+  options '--force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"' if node.platform_family?('debian')
   notifies :restart, 'service[graylog-web]', node.graylog2[:restart].to_sym
 end
 


### PR DESCRIPTION
debian platform --force-yes option was always being overridden by platform family option call. Also switch to Recipe DSL for platform family calls.