### PR TITLE
Make collector work and work when installed on its own

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,7 @@ version '1.2.0'
 
 depends 'authbind', '>= 0.1.8'
 depends 'java'
+depends 'ark'
 
 recommends 'mongodb'
 recommends 'elasticsearch'

--- a/recipes/collector.rb
+++ b/recipes/collector.rb
@@ -31,6 +31,7 @@ end
 
 directory '/etc/graylog/collector' do
   action :create
+  recursive true
   owner node.graylog2[:collector][:user]
   group node.graylog2[:collector][:group]
 end


### PR DESCRIPTION
Right now chef fails out when installing just collector, due to requirements not being set properly and not creating the /etc/graylog/collector/ directory. This fixes that.