### PR TITLE
Make installation of tzdata-java package optional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -207,6 +207,7 @@ default.graylog2[:dead_letters_enabled] = false
 # Server
 default.graylog2[:server][:override_restart_command] = false
 default.graylog2[:server][:additional_options]       = nil
+default.graylog2[:server][:install_tzdata_java]      = true
 
 # Web
 default.graylog2[:web][:java_bin] = '/usr/bin/java'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,7 +15,8 @@ if node.graylog2[:elasticsearch][:unicast_search_query] && node.graylog2[:elasti
   node.set[:graylog2][:elasticsearch][:discovery_zen_ping_unicast_hosts] = nodes.map { |ip| ip + ':9300' }.join(',')
 end
 
-package 'tzdata-java'
+package 'tzdata-java' if node.graylog2[:server][:install_tzdata_java]
+
 package 'graylog-server' do
   action :install
   version node.graylog2[:server][:version]


### PR DESCRIPTION
Small modification to the server recipe, to make the tzdata-java package optional.
Adds a default config which _does_ install the package by default.

Environments with non-default JDK installations don't make use of the OS tzdata-java package.