### PR TITLE
Add the ability to add additional environment variables to the sysconfig file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -204,6 +204,7 @@ default.graylog2[:web][:args]         = ''
 # Server
 default.graylog2[:server][:override_restart_command] = false
 default.graylog2[:server][:additional_options]       = nil
+default.graylog2[:server][:additional_env_vars]      = nil
 default.graylog2[:server][:install_tzdata_java]      = true
 
 # Web
@@ -276,4 +277,3 @@ default.graylog2[:server][:collector_expiration_threshold]  = '14d'
 default.graylog2[:server][:content_packs_loader_enabled] = false
 default.graylog2[:server][:content_packs_dir] = '/usr/share/graylog-server/data/contentpacks'
 default.graylog2[:server][:content_packs_auto_load] = 'grok-patterns.json'
-

--- a/templates/default/graylog.server.default.erb
+++ b/templates/default/graylog.server.default.erb
@@ -12,3 +12,6 @@ GRAYLOG_SERVER_ARGS="<%= node.graylog2[:server][:args] %>"
 # Program that will be used to wrap the graylog-server command. Useful to
 # support programs like authbind.
 GRAYLOG_COMMAND_WRAPPER="<%= node.graylog2[:server][:wrapper] %>"
+
+# Additional environment variables
+<%= node.graylog2[:server][:additional_env_vars] -%>


### PR DESCRIPTION
I'd like to be able to add an environment variable to sysconfig to store a password that is used in a custom Graylog plugin (I don't want to store the password in git). I used the same approach that is already in place for additional options for the server config.