### PR TITLE
Determining of master node when machine has multiple network interfaces

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -53,11 +53,8 @@ service 'graylog-server' do
   provider Chef::Provider::Service::Upstart if platform?('ubuntu')
 end
 
-is_master = if node.graylog2[:ip_of_master] == node.ipaddress
-              true
-            else
-              false
-            end
+is_master = node.graylog2[:is_master]
+is_master ||= node.graylog2[:ip_of_master] == node.ipaddress
 
 template '/etc/graylog/server/server.conf' do
   source 'graylog.server.conf.erb'


### PR DESCRIPTION
Hi,

i am having problem with setting up my master node when machine has two or more network interfaces. ```node.ipaddress``` always holds ip assigned to first adapter. Suggested change allows wrapper coookbooks to make own decisions about how to specify master node.
