### PR TITLE
Remove instances of method access for node attributes, fixes #78

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,227 +1,227 @@
-node.default[:graylog2] ||= {}
-node.default[:mongodb] ||= {}
+node.default['graylog2'] ||= {}
+node.default['mongodb'] ||= {}
 
 # General
-default.graylog2[:repo_version]              = '1-1'
-default.graylog2[:major_version]             = '2.1'
-default.graylog2[:server][:version]          = '2.1.1-1'
+default['graylog2']['repo_version']              = '1-1'
+default['graylog2']['major_version']             = '2.1'
+default['graylog2']['server']['version']          = '2.1.1-1'
 ## By default the cookbook installs a meta package containing the key and URL for the current Graylog repository. To disable
 ## this behavior set your own repository informations here.
-default.graylog2[:server][:repos]            = {
+default['graylog2']['server']['repos']            = {
 #  'rhel' => {
-#    'url' => "https://packages.graylog2.org/repo/el/stable/#{node.graylog2[:major_version]}/x86_64/",
+#    'url' => "https://packages.graylog2.org/repo/el/stable/#{node['graylog2']['major_version']}/x86_64/",
 #    'key' => 'https://raw.githubusercontent.com/Graylog2/fpm-recipes/master/recipes/graylog-repository/files/rpm/RPM-GPG-KEY-graylog'
 #  },
 #  'debian' => {
 #    'url' => "https://packages.graylog2.org/repo/debian/",
 #    'distribution' => '',
-#    'components' => ['stable', node.graylog2[:major_version]],
+#    'components' => ['stable', node['graylog2']['major_version']],
 #    'key' => 'https://raw.githubusercontent.com/Graylog2/fpm-recipes/master/recipes/graylog-repository/files/deb/graylog-keyring.gpg'
 #  }
 }
-default.graylog2[:root_username]             = 'admin'
-default.graylog2[:root_email]                = nil
-default.graylog2[:root_timezone]             = nil
-default.graylog2[:restart]                   = 'delayed'
-default.graylog2[:no_retention]              = nil
-default.graylog2[:disable_sigar]             = nil
-default.graylog2[:dashboard_widget_default_cache_time] = '10s'
-default.graylog2[:secrets_data_bag]                    = 'secrets'
+default['graylog2']['root_username']             = 'admin'
+default['graylog2']['root_email']                = nil
+default['graylog2']['root_timezone']             = nil
+default['graylog2']['restart']                   = 'delayed'
+default['graylog2']['no_retention']              = nil
+default['graylog2']['disable_sigar']             = nil
+default['graylog2']['dashboard_widget_default_cache_time'] = '10s'
+default['graylog2']['secrets_data_bag']                    = 'secrets'
 
 # Users
-default.graylog2[:server][:user]  = 'graylog'
-default.graylog2[:server][:group] = 'graylog'
+default['graylog2']['server']['user']  = 'graylog'
+default['graylog2']['server']['group'] = 'graylog'
 
 # SHAs
-default.graylog2[:password_secret]              = nil # pwgen -s 96 1
-default.graylog2[:password_secret_enclose_char] = '"'
-default.graylog2[:root_password_sha2]           = nil # echo -n yourpassword | shasum -a 256
+default['graylog2']['password_secret']              = nil # pwgen -s 96 1
+default['graylog2']['password_secret_enclose_char'] = '"'
+default['graylog2']['root_password_sha2']           = nil # echo -n yourpassword | shasum -a 256
 
 # Paths
-default.graylog2[:node_id_file] = '/etc/graylog/server/node-id'
-default.graylog2[:plugin_dir]   = '/usr/share/graylog-server/plugin'
+default['graylog2']['node_id_file'] = '/etc/graylog/server/node-id'
+default['graylog2']['plugin_dir']   = '/usr/share/graylog-server/plugin'
 
 # Network
-default.graylog2[:trusted_proxies]  = nil
-default.graylog2[:http_proxy_uri]   = nil
-default.graylog2[:authorized_ports] = 514
+default['graylog2']['trusted_proxies']  = nil
+default['graylog2']['http_proxy_uri']   = nil
+default['graylog2']['authorized_ports'] = 514
 
 # Rest
-default.graylog2[:rest][:listen_uri]              = 'http://0.0.0.0:9000/api'
-default.graylog2[:rest][:transport_uri]           = nil
-default.graylog2[:rest][:enable_cors]             = nil
-default.graylog2[:rest][:enable_gzip]             = nil
-default.graylog2[:rest][:admin_access_token]      = nil # pwgen -s 96 1
-default.graylog2[:rest][:enable_tls]              = nil
-default.graylog2[:rest][:tls_cert_file]           = nil
-default.graylog2[:rest][:tls_key_file]            = nil
-default.graylog2[:rest][:tls_key_password]        = nil
-default.graylog2[:rest][:max_chunk_size]          = nil
-default.graylog2[:rest][:max_header_size]         = nil
-default.graylog2[:rest][:max_initial_line_length] = nil
-default.graylog2[:rest][:thread_pool_size]        = nil
-default.graylog2[:rest][:worker_threads_max_pool_size] = nil
+default['graylog2']['rest']['listen_uri']              = 'http://0.0.0.0:9000/api'
+default['graylog2']['rest']['transport_uri']           = nil
+default['graylog2']['rest']['enable_cors']             = nil
+default['graylog2']['rest']['enable_gzip']             = nil
+default['graylog2']['rest']['admin_access_token']      = nil # pwgen -s 96 1
+default['graylog2']['rest']['enable_tls']              = nil
+default['graylog2']['rest']['tls_cert_file']           = nil
+default['graylog2']['rest']['tls_key_file']            = nil
+default['graylog2']['rest']['tls_key_password']        = nil
+default['graylog2']['rest']['max_chunk_size']          = nil
+default['graylog2']['rest']['max_header_size']         = nil
+default['graylog2']['rest']['max_initial_line_length'] = nil
+default['graylog2']['rest']['thread_pool_size']        = nil
+default['graylog2']['rest']['worker_threads_max_pool_size'] = nil
 
 # Elasticsearch
-default.graylog2[:elasticsearch][:config_file]                          = '/etc/graylog/server/graylog-elasticsearch.yml'
-default.graylog2[:elasticsearch][:shards]                               = 4
-default.graylog2[:elasticsearch][:replicas]                             = 0
-default.graylog2[:elasticsearch][:index_prefix]                         = 'graylog'
-default.graylog2[:elasticsearch][:cluster_name]                         = 'graylog'
-default.graylog2[:elasticsearch][:http_enabled]                         = false
-default.graylog2[:elasticsearch][:discovery_zen_ping_unicast_hosts]     = '127.0.0.1:9300'
-default.graylog2[:elasticsearch][:unicast_search_query]                 = nil
-default.graylog2[:elasticsearch][:search_node_attribute]                = nil
-default.graylog2[:elasticsearch][:network_host]                         = nil
-default.graylog2[:elasticsearch][:network_bind_host]                    = nil
-default.graylog2[:elasticsearch][:network_publish_host]                 = nil
-default.graylog2[:elasticsearch][:analyzer]                             = 'standard'
-default.graylog2[:elasticsearch][:output_batch_size]                    = 500
-default.graylog2[:elasticsearch][:output_flush_interval]                = 1
-default.graylog2[:elasticsearch][:output_fault_count_threshold]         = 5
-default.graylog2[:elasticsearch][:output_fault_penalty_seconds]         = 30
-default.graylog2[:elasticsearch][:transport_tcp_port]                   = 9350
-default.graylog2[:elasticsearch][:disable_version_check]                = nil
-default.graylog2[:elasticsearch][:disable_index_optimization]           = nil
-default.graylog2[:elasticsearch][:index_optimization_max_num_segments]  = nil
-default.graylog2[:elasticsearch][:index_ranges_cleanup_interval]        = nil
-default.graylog2[:elasticsearch][:template_name]                        = nil
-default.graylog2[:elasticsearch][:node_name_prefix]                     = nil
-default.graylog2[:elasticsearch][:template_name]                        = nil
+default['graylog2']['elasticsearch']['config_file']                          = '/etc/graylog/server/graylog-elasticsearch.yml'
+default['graylog2']['elasticsearch']['shards']                               = 4
+default['graylog2']['elasticsearch']['replicas']                             = 0
+default['graylog2']['elasticsearch']['index_prefix']                         = 'graylog'
+default['graylog2']['elasticsearch']['cluster_name']                         = 'graylog'
+default['graylog2']['elasticsearch']['http_enabled']                         = false
+default['graylog2']['elasticsearch']['discovery_zen_ping_unicast_hosts']     = '127.0.0.1:9300'
+default['graylog2']['elasticsearch']['unicast_search_query']                 = nil
+default['graylog2']['elasticsearch']['search_node_attribute']                = nil
+default['graylog2']['elasticsearch']['network_host']                         = nil
+default['graylog2']['elasticsearch']['network_bind_host']                    = nil
+default['graylog2']['elasticsearch']['network_publish_host']                 = nil
+default['graylog2']['elasticsearch']['analyzer']                             = 'standard'
+default['graylog2']['elasticsearch']['output_batch_size']                    = 500
+default['graylog2']['elasticsearch']['output_flush_interval']                = 1
+default['graylog2']['elasticsearch']['output_fault_count_threshold']         = 5
+default['graylog2']['elasticsearch']['output_fault_penalty_seconds']         = 30
+default['graylog2']['elasticsearch']['transport_tcp_port']                   = 9350
+default['graylog2']['elasticsearch']['disable_version_check']                = nil
+default['graylog2']['elasticsearch']['disable_index_optimization']           = nil
+default['graylog2']['elasticsearch']['index_optimization_max_num_segments']  = nil
+default['graylog2']['elasticsearch']['index_ranges_cleanup_interval']        = nil
+default['graylog2']['elasticsearch']['template_name']                        = nil
+default['graylog2']['elasticsearch']['node_name_prefix']                     = nil
+default['graylog2']['elasticsearch']['template_name']                        = nil
 
 # MongoDb
-default.graylog2[:mongodb][:uri] = 'mongodb://127.0.0.1:27017/graylog'
-default.graylog2[:mongodb][:max_connections] = 100
-default.graylog2[:mongodb][:threads_allowed_to_block_multiplier] = 5
+default['graylog2']['mongodb']['uri'] = 'mongodb://127.0.0.1:27017/graylog'
+default['graylog2']['mongodb']['max_connections'] = 100
+default['graylog2']['mongodb']['threads_allowed_to_block_multiplier'] = 5
 
 # Search
-default.graylog2[:allow_leading_wildcard_searches] = false
-default.graylog2[:allow_highlighting]              = false
+default['graylog2']['allow_leading_wildcard_searches'] = false
+default['graylog2']['allow_highlighting']              = false
 
 # Streams
-default.graylog2[:stream_processing_max_faults] = 3
+default['graylog2']['stream_processing_max_faults'] = 3
 
 # Buffer
-default.graylog2[:processbuffer_processors]  = 5
-default.graylog2[:outputbuffer_processors]   = 3
-default.graylog2[:async_eventbus_processors] = 2
-default.graylog2[:outputbuffer_processor_keep_alive_time]        = 5000
-default.graylog2[:outputbuffer_processor_threads_core_pool_size] = 3
-default.graylog2[:outputbuffer_processor_threads_max_pool_size]  = 30
-default.graylog2[:processor_wait_strategy]   = 'blocking'
-default.graylog2[:ring_size]                 = 65536
-default.graylog2[:udp_recvbuffer_sizes]      = 1048576
-default.graylog2[:inputbuffer_ring_size]     = 65536
-default.graylog2[:inputbuffer_processors]    = 2
-default.graylog2[:inputbuffer_wait_strategy] = 'blocking'
+default['graylog2']['processbuffer_processors']  = 5
+default['graylog2']['outputbuffer_processors']   = 3
+default['graylog2']['async_eventbus_processors'] = 2
+default['graylog2']['outputbuffer_processor_keep_alive_time']        = 5000
+default['graylog2']['outputbuffer_processor_threads_core_pool_size'] = 3
+default['graylog2']['outputbuffer_processor_threads_max_pool_size']  = 30
+default['graylog2']['processor_wait_strategy']   = 'blocking'
+default['graylog2']['ring_size']                 = 65536
+default['graylog2']['udp_recvbuffer_sizes']      = 1048576
+default['graylog2']['inputbuffer_ring_size']     = 65536
+default['graylog2']['inputbuffer_processors']    = 2
+default['graylog2']['inputbuffer_wait_strategy'] = 'blocking'
 
 # Message journal
-default.graylog2[:message_journal_enabled]        = true
-default.graylog2[:message_journal_dir]            = '/var/lib/graylog-server/journal'
-default.graylog2[:message_journal_max_age]        = '12h'
-default.graylog2[:message_journal_max_size]       = '5gb'
-default.graylog2[:message_journal_flush_age]      = '1m'
-default.graylog2[:message_journal_flush_interval] = 1000000
-default.graylog2[:message_journal_segment_age]    = '1h'
-default.graylog2[:message_journal_segment_size]   = '100mb'
+default['graylog2']['message_journal_enabled']        = true
+default['graylog2']['message_journal_dir']            = '/var/lib/graylog-server/journal'
+default['graylog2']['message_journal_max_age']        = '12h'
+default['graylog2']['message_journal_max_size']       = '5gb'
+default['graylog2']['message_journal_flush_age']      = '1m'
+default['graylog2']['message_journal_flush_interval'] = 1000000
+default['graylog2']['message_journal_segment_age']    = '1h'
+default['graylog2']['message_journal_segment_size']   = '100mb'
 
 # Timeouts
-default.graylog2[:output_module_timeout]     = 10000
-default.graylog2[:stale_master_timeout]      = 2000
-default.graylog2[:shutdown_timeout]          = 30000
-default.graylog2[:stream_processing_timeout] = 2000
-default.graylog2[:ldap_connection_timeout]   = 2000
-default.graylog2[:api_client_timeout]        = 300
-default.graylog2[:http_connect_timeout]      = '5s'
-default.graylog2[:http_read_timeout]         = '10s'
-default.graylog2[:http_write_timeout]        = '10s'
-default.graylog2[:elasticsearch][:cluster_discovery_timeout]       = 5000
-default.graylog2[:elasticsearch][:discovery_initial_state_timeout] = '3s'
-default.graylog2[:elasticsearch][:request_timeout]                 = '1m'
+default['graylog2']['output_module_timeout']     = 10000
+default['graylog2']['stale_master_timeout']      = 2000
+default['graylog2']['shutdown_timeout']          = 30000
+default['graylog2']['stream_processing_timeout'] = 2000
+default['graylog2']['ldap_connection_timeout']   = 2000
+default['graylog2']['api_client_timeout']        = 300
+default['graylog2']['http_connect_timeout']      = '5s'
+default['graylog2']['http_read_timeout']         = '10s'
+default['graylog2']['http_write_timeout']        = '10s'
+default['graylog2']['elasticsearch']['cluster_discovery_timeout']       = 5000
+default['graylog2']['elasticsearch']['discovery_initial_state_timeout'] = '3s'
+default['graylog2']['elasticsearch']['request_timeout']                 = '1m'
 
 # Intervals
-default.graylog2[:server][:alert_check_interval] = nil
+default['graylog2']['server']['alert_check_interval'] = nil
 
 # Cluster
-default.graylog2[:ip_of_master]                  = node.ipaddress
-default.graylog2[:lb_recognition_period_seconds] = 3
+default['graylog2']['ip_of_master']                  = node.ipaddress
+default['graylog2']['lb_recognition_period_seconds'] = 3
 
 # Email transport
-default.graylog2[:transport_email_enabled]           = false
-default.graylog2[:transport_email_hostname]          = 'mail.example.com'
-default.graylog2[:transport_email_port]              = 587
-default.graylog2[:transport_email_use_auth]          = true
-default.graylog2[:transport_email_use_tls]           = true
-default.graylog2[:transport_email_use_ssl]           = true
-default.graylog2[:transport_email_auth_username]     = 'you@example.com'
-default.graylog2[:transport_email_auth_password]     = 'secret'
-default.graylog2[:transport_email_subject_prefix]    = '[graylog]'
-default.graylog2[:transport_email_from_email]        = 'graylog@example.com'
-default.graylog2[:transport_email_web_interface_url] = nil
+default['graylog2']['transport_email_enabled']           = false
+default['graylog2']['transport_email_hostname']          = 'mail.example.com'
+default['graylog2']['transport_email_port']              = 587
+default['graylog2']['transport_email_use_auth']          = true
+default['graylog2']['transport_email_use_tls']           = true
+default['graylog2']['transport_email_use_ssl']           = true
+default['graylog2']['transport_email_auth_username']     = 'you@example.com'
+default['graylog2']['transport_email_auth_password']     = 'secret'
+default['graylog2']['transport_email_subject_prefix']    = '[graylog]'
+default['graylog2']['transport_email_from_email']        = 'graylog@example.com'
+default['graylog2']['transport_email_web_interface_url'] = nil
 
 # Logging
-default.graylog2[:server][:log_file]              = '/var/log/graylog-server/server.log'
-default.graylog2[:server][:log_max_size]          = '50MB'
-default.graylog2[:server][:log_max_index]         = 10
-default.graylog2[:server][:log_pattern]           = "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5p [%c{1}] %m%n"
-default.graylog2[:server][:log_level_application] = 'info'
-default.graylog2[:server][:log_level_root]        = 'warn'
+default['graylog2']['server']['log_file']              = '/var/log/graylog-server/server.log'
+default['graylog2']['server']['log_max_size']          = '50MB'
+default['graylog2']['server']['log_max_index']         = 10
+default['graylog2']['server']['log_pattern']           = "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5p [%c{1}] %m%n"
+default['graylog2']['server']['log_level_application'] = 'info'
+default['graylog2']['server']['log_level_root']        = 'warn'
 
 # JVM
-default.graylog2[:server][:java_bin] = '/usr/bin/java'
-default.graylog2[:server][:java_home] = ''
-default.graylog2[:server][:java_opts] = '-Djava.net.preferIPv4Stack=true -Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow'
-default.graylog2[:server][:args]      = ''
-default.graylog2[:server][:wrapper]   = ''
-default.graylog2[:server][:gc_warning_threshold] = nil
+default['graylog2']['server']['java_bin'] = '/usr/bin/java'
+default['graylog2']['server']['java_home'] = ''
+default['graylog2']['server']['java_opts'] = '-Djava.net.preferIPv4Stack=true -Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow'
+default['graylog2']['server']['args']      = ''
+default['graylog2']['server']['wrapper']   = ''
+default['graylog2']['server']['gc_warning_threshold'] = nil
 
 # Server
-default.graylog2[:server][:override_restart_command] = false
-default.graylog2[:server][:additional_options]       = nil
-default.graylog2[:server][:additional_env_vars]      = nil
-default.graylog2[:server][:install_tzdata_java]      = true
+default['graylog2']['server']['override_restart_command'] = false
+default['graylog2']['server']['additional_options']       = nil
+default['graylog2']['server']['additional_env_vars']      = nil
+default['graylog2']['server']['install_tzdata_java']      = true
 
 # Web
-default.graylog2[:web][:enable] = true
-default.graylog2[:web][:listen_uri] = 'http://0.0.0.0:9000'
-default.graylog2[:web][:endpoint_uri] = nil
-default.graylog2[:web][:enable_cors] = nil
-default.graylog2[:web][:enable_gzip] = nil
-default.graylog2[:web][:enable_tls] = nil
-default.graylog2[:web][:tls_cert_file] = nil
-default.graylog2[:web][:tls_key_file] = nil
-default.graylog2[:web][:tls_key_password] = nil
-default.graylog2[:web][:max_header_size] = nil
-default.graylog2[:web][:max_initial_line_length] = nil
-default.graylog2[:web][:thread_pool_size] = nil
+default['graylog2']['web']['enable'] = true
+default['graylog2']['web']['listen_uri'] = 'http://0.0.0.0:9000'
+default['graylog2']['web']['endpoint_uri'] = nil
+default['graylog2']['web']['enable_cors'] = nil
+default['graylog2']['web']['enable_gzip'] = nil
+default['graylog2']['web']['enable_tls'] = nil
+default['graylog2']['web']['tls_cert_file'] = nil
+default['graylog2']['web']['tls_key_file'] = nil
+default['graylog2']['web']['tls_key_password'] = nil
+default['graylog2']['web']['max_header_size'] = nil
+default['graylog2']['web']['max_initial_line_length'] = nil
+default['graylog2']['web']['thread_pool_size'] = nil
 
 # Collector Sidecar
-default.graylog2[:sidecar][:release]                        = '0.0.9'
-default.graylog2[:sidecar][:version]                        = '0.0.9'
-default.graylog2[:sidecar][:build]                          = 1
-default.graylog2[:sidecar][:arch]                           = 'amd64'
-default.graylog2[:sidecar][:package_base_url]               = "https://github.com/Graylog2/collector-sidecar/releases/download/#{node.graylog2[:sidecar][:release]}"
-default.graylog2[:sidecar][:server_url]                     = 'http://localhost:9000/api'
-default.graylog2[:sidecar][:update_interval]                = 10
-default.graylog2[:sidecar][:tls_skip_verify]                = false
-default.graylog2[:sidecar][:send_status]                    = false
-default.graylog2[:sidecar][:list_log_files]                 = nil # single directory or '[dir1, dir2, dir3]'
-default.graylog2[:sidecar][:name]                           = 'graylog-collector-sidecar'
-default.graylog2[:sidecar][:id]                             = 'file:/etc/graylog/collector-sidecar/collector-id'
-default.graylog2[:sidecar][:log_path]                       = '/var/log/graylog/collector-sidecar'
-default.graylog2[:sidecar][:log_rotation_time]              = 86400
-default.graylog2[:sidecar][:log_max_age]                    = 604800
-default.graylog2[:sidecar][:tags]                           = 'linux' # multiple tags '[tag1, tag2, tag3]'
-default.graylog2[:sidecar][:backends][:nxlog][:enabled]               = false
-default.graylog2[:sidecar][:backends][:nxlog][:binary_path]           = '/usr/bin/nxlog'
-default.graylog2[:sidecar][:backends][:nxlog][:configuration_path]    = '/etc/graylog/collector-sidecar/generated/nxlog.conf'
-default.graylog2[:sidecar][:backends][:filebeat][:enabled]            = true
-default.graylog2[:sidecar][:backends][:filebeat][:binary_path]        = '/usr/bin/filebeat'
-default.graylog2[:sidecar][:backends][:filebeat][:configuration_path] = '/etc/graylog/collector-sidecar/generated/filebeat.yml'
-default.graylog2[:server][:collector_inactive_threshold]    = '1m'
-default.graylog2[:server][:collector_expiration_threshold]  = '14d'
+default['graylog2']['sidecar']['release']                        = '0.0.9'
+default['graylog2']['sidecar']['version']                        = '0.0.9'
+default['graylog2']['sidecar']['build']                          = 1
+default['graylog2']['sidecar']['arch']                           = 'amd64'
+default['graylog2']['sidecar']['package_base_url']               = "https://github.com/Graylog2/collector-sidecar/releases/download/#{node['graylog2']['sidecar'][:release]}"
+default['graylog2']['sidecar']['server_url']                     = 'http://localhost:9000/api'
+default['graylog2']['sidecar']['update_interval']                = 10
+default['graylog2']['sidecar']['tls_skip_verify']                = false
+default['graylog2']['sidecar']['send_status']                    = false
+default['graylog2']['sidecar']['list_log_files']                 = nil # single directory or '[dir1, dir2, dir3]'
+default['graylog2']['sidecar']['name']                           = 'graylog-collector-sidecar'
+default['graylog2']['sidecar']['id']                             = 'file:/etc/graylog/collector-sidecar/collector-id'
+default['graylog2']['sidecar']['log_path']                       = '/var/log/graylog/collector-sidecar'
+default['graylog2']['sidecar']['log_rotation_time']              = 86400
+default['graylog2']['sidecar']['log_max_age']                    = 604800
+default['graylog2']['sidecar']['tags']                           = 'linux' # multiple tags '[tag1, tag2, tag3]'
+default['graylog2']['sidecar']['backends']['nxlog']['enabled']               = false
+default['graylog2']['sidecar']['backends']['nxlog']['binary_path']           = '/usr/bin/nxlog'
+default['graylog2']['sidecar']['backends']['nxlog']['configuration_path']    = '/etc/graylog/collector-sidecar/generated/nxlog.conf'
+default['graylog2']['sidecar']['backends']['filebeat']['enabled']            = true
+default['graylog2']['sidecar']['backends']['filebeat']['binary_path']        = '/usr/bin/filebeat'
+default['graylog2']['sidecar']['backends']['filebeat']['configuration_path'] = '/etc/graylog/collector-sidecar/generated/filebeat.yml'
+default['graylog2']['server']['collector_inactive_threshold']    = '1m'
+default['graylog2']['server']['collector_expiration_threshold']  = '14d'
 
 # Content packs
-default.graylog2[:server][:content_packs_loader_enabled] = false
-default.graylog2[:server][:content_packs_dir]            = '/usr/share/graylog-server/contentpacks'
-default.graylog2[:server][:content_packs_auto_load]      = 'grok-patterns.json'
+default['graylog2']['server']['content_packs_loader_enabled'] = false
+default['graylog2']['server']['content_packs_dir']            = '/usr/share/graylog-server/contentpacks'
+default['graylog2']['server']['content_packs_auto_load']      = 'grok-patterns.json'

--- a/recipes/authbind.rb
+++ b/recipes/authbind.rb
@@ -1,21 +1,21 @@
 if platform?('ubuntu', 'debian')
   include_recipe 'authbind::default'
 
-  node.default.graylog2[:server][:wrapper] = 'authbind'
-  node.default.graylog2[:radio][:wrapper]  = 'authbind'
-  if node.graylog2[:authorized_ports].is_a?(Array)
-    node.graylog2[:authorized_ports].each do |authorized_port|
+  node.default['graylog2']['server']['wrapper'] = 'authbind'
+  node.default['graylog2']['radio']['wrapper']  = 'authbind'
+  if node['graylog2']['authorized_ports'].is_a?(Array)
+    node['graylog2']['authorized_ports'].each do |authorized_port|
       authbind_port "AuthBind graylog-server port #{authorized_port}" do
         port authorized_port
-        user node.graylog2[:server][:user]
-        only_if "getent passwd #{node.graylog2[:server][:user]}"
+        user node['graylog2']['server']['user']
+        only_if "getent passwd #{node['graylog2']['server']['user']}"
       end
     end
-  elsif !node.graylog2[:authorized_ports].nil?
-    authbind_port "AuthBind graylog-server port #{node.graylog2[:authorized_ports]}" do
-      port node.graylog2[:authorized_ports]
-      user node.graylog2[:server][:user]
-      only_if "getent passwd #{node.graylog2[:server][:user]}"
+  elsif !node['graylog2']['authorized_ports'].nil?
+    authbind_port "AuthBind graylog-server port #{node['graylog2']['authorized_ports']}" do
+      port node['graylog2']['authorized_ports']
+      user node['graylog2']['server']['user']
+      only_if "getent passwd #{node['graylog2']['server']['user']}"
     end
   end
 else

--- a/recipes/collector_sidecar.rb
+++ b/recipes/collector_sidecar.rb
@@ -1,25 +1,25 @@
 package_name = String.new
 arch = String.new
 
-case node[:platform]
+case node['platform']
 when 'ubuntu', 'debian'
-  arch = (['amd64', 'x64', 'x86_64'].include? node.graylog2[:sidecar][:arch]) ? 'amd64' : 'i386'
-  package_name = "collector-sidecar_#{node.graylog2[:sidecar][:version]}-#{node.graylog2[:sidecar]['build']}_#{arch}.deb"
+  arch = (['amd64', 'x64', 'x86_64'].include? node['graylog2']['sidecar']['arch']) ? 'amd64' : 'i386'
+  package_name = "collector-sidecar_#{node['graylog2']['sidecar']['version']}-#{node['graylog2']['sidecar']['build']}_#{arch}.deb"
 when 'redhat', 'centos'
-  arch = (['amd64', 'x64', 'x86_64'].include? node.graylog2[:sidecar][:arch]) ? 'x86_64' : 'i386'
-  package_name = "collector-sidecar-#{node.graylog2[:sidecar][:version]}-#{node.graylog2[:sidecar]['build']}.#{arch}.rpm"
+  arch = (['amd64', 'x64', 'x86_64'].include? node['graylog2']['sidecar']['arch']) ? 'x86_64' : 'i386'
+  package_name = "collector-sidecar-#{node['graylog2']['sidecar']['version']}-#{node['graylog2']['sidecar']['build']}.#{arch}.rpm"
 end
 
 remote_file "#{Chef::Config['file_cache_path'] || '/tmp'}/#{package_name}" do
-  source "#{node.graylog2[:sidecar][:package_base_url]}/#{package_name}"
+  source "#{node['graylog2']['sidecar']['package_base_url']}/#{package_name}"
   action :create_if_missing
 end
 
 package 'graylog-collector-sidecar' do
   action :install
   source "#{Chef::Config['file_cache_path'] || '/tmp'}/#{package_name}"
-  version "#{node.graylog2[:sidecar][:version]}-#{node.graylog2[:sidecar]['build']}"
-  case node[:platform]
+  version "#{node['graylog2']['sidecar']['version']}-#{node['graylog2']['sidecar']['build']}"
+  case node['platform']
   when 'ubuntu', 'debian'
     provider Chef::Provider::Package::Dpkg
     options '--force-confold'
@@ -38,7 +38,7 @@ end
 execute 'install service graylog-collector-sidecar' do
   command '/usr/bin/graylog-collector-sidecar -service install'
   notifies :restart, 'service[collector-sidecar]'
-  case node[:platform]
+  case node['platform']
   when 'ubuntu'
     not_if { File.exists?('/etc/init/collector-sidecar.conf') }
   when 'debian', 'redhat', 'centos'
@@ -49,4 +49,3 @@ end
 service 'collector-sidecar' do
   action [:enable, :start]
 end
-

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,6 @@
-version = node.graylog2[:major_version]
-repo_version = node.graylog2[:repo_version]
-raise('Java version needs to be >= 8') if node[:java][:jdk_version].to_i < 8
+version = node['graylog2']['major_version']
+repo_version = node['graylog2']['repo_version']
+raise('Java version needs to be >= 8') if node['java']['jdk_version'].to_i < 8
 
 if platform_family?('rhel')
   repository_file = "graylog-#{version}-repository-#{repo_version}.noarch.rpm"
@@ -28,7 +28,7 @@ execute 'yum-clean' do
   action :nothing
 end
 
-if node.graylog2[:server][:repos].empty?
+if node['graylog2']['server']['repos'].empty?
   package repository_file do
     action :install
     source "#{Chef::Config[:file_cache_path]}/#{repository_file}"
@@ -46,15 +46,15 @@ else
   if platform_family?('rhel')
     yum_repository 'graylog' do
       description "Graylog repository"
-      baseurl     node.graylog2[:server][:repos]['rhel']['url']
-      gpgkey      node.graylog2[:server][:repos]['rhel']['key']
+      baseurl     node['graylog2']['server']['repos']['rhel']['url']
+      gpgkey      node['graylog2']['server']['repos']['rhel']['key']
     end
   elsif platform?('ubuntu', 'debian')
     apt_repository 'graylog' do
-      uri          node.graylog2[:server][:repos]['debian']['url']
-      distribution node.graylog2[:server][:repos]['debian']['distribution'] 
-      components   node.graylog2[:server][:repos]['debian']['components']
-      key          node.graylog2[:server][:repos]['debian']['key']
+      uri          node['graylog2']['server']['repos']['debian']['url']
+      distribution node['graylog2']['server']['repos']['debian']['distribution']
+      components   node['graylog2']['server']['repos']['debian']['components']
+      key          node['graylog2']['server']['repos']['debian']['key']
     end
   end
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,80 +1,80 @@
 # Override attributes from data bag's "server" section
 secrets = {}
 begin
-  secrets = Chef::EncryptedDataBagItem.load(node.graylog2[:secrets_data_bag], 'graylog')['server']
+  secrets = Chef::EncryptedDataBagItem.load(node['graylog2']['secrets_data_bag'], 'graylog')['server']
 rescue
   Chef::Log.debug 'Can not load server secrets from databag'
 end
-password_secret = secrets['password_secret'] || node.graylog2[:password_secret]
-root_password_sha2 = secrets['root_password_sha2'] || node.graylog2[:root_password_sha2]
+password_secret = secrets['password_secret'] || node['graylog2']['password_secret']
+root_password_sha2 = secrets['root_password_sha2'] || node['graylog2']['root_password_sha2']
 raise('No password_secret set, either set it via an attribute or in the encrypted data bag in secrets.graylog') unless password_secret
 raise('No root_password_sha2 set, either set it via an attribute or in the encrypted data bag in secrets.graylog') unless root_password_sha2
 
 # Search ES cluster
-if node.graylog2[:elasticsearch][:unicast_search_query] && node.graylog2[:elasticsearch][:search_node_attribute]
-  nodes = search_for_nodes(node.graylog2[:elasticsearch][:unicast_search_query], node.graylog2[:elasticsearch][:search_node_attribute])
+if node['graylog2']['elasticsearch']['unicast_search_query'] && node['graylog2']['elasticsearch']['search_node_attribute']
+  nodes = search_for_nodes(node['graylog2']['elasticsearch']['unicast_search_query'], node['graylog2']['elasticsearch']['search_node_attribute'])
   Chef::Log.debug("Found elasticsearch nodes at #{nodes.join(', ').inspect}")
-  node.set[:graylog2][:elasticsearch][:discovery_zen_ping_unicast_hosts] = nodes.map { |ip| ip + ':9300' }.join(',')
+  node.set['graylog2']['elasticsearch']['discovery_zen_ping_unicast_hosts'] = nodes.map { |ip| ip + ':9300' }.join(',')
 end
 
-package 'tzdata-java' if node.graylog2[:server][:install_tzdata_java]
+package 'tzdata-java' if node['graylog2']['server']['install_tzdata_java']
 
 package 'graylog-server' do
   action :install
-  version node.graylog2[:server][:version]
+  version node['graylog2']['server']['version']
   options '--no-install-recommends --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"' if platform_family?('debian')
-  notifies :restart, 'service[graylog-server]', node.graylog2[:restart].to_sym
+  notifies :restart, 'service[graylog-server]', node['graylog2']['restart'].to_sym
 end
 
 ruby_block 'create node-id if needed' do
   block do
-    File.write(node.graylog2[:node_id_file], SecureRandom.uuid)
+    File.write(node['graylog2']['node_id_file'], SecureRandom.uuid)
   end
-  not_if { ::File.exist?(node.graylog2[:node_id_file]) }
+  not_if { ::File.exist?(node['graylog2']['node_id_file']) }
 end
 
 directory '/var/run/graylog' do
   action :create
-  owner node.graylog2[:server][:user]
-  group node.graylog2[:server][:group]
+  owner node['graylog2']['server']['user']
+  group node['graylog2']['server']['group']
 end
 
-directory File.dirname(node.graylog2[:server][:log_file]) do
+directory File.dirname(node['graylog2']['server']['log_file']) do
   action :create
   recursive true
-  owner node.graylog2[:server][:user]
-  group node.graylog2[:server][:group]
+  owner node['graylog2']['server']['user']
+  group node['graylog2']['server']['group']
 end
 
 service 'graylog-server' do
   action [:enable, :start]
-  restart_command node.graylog2[:server][:override_restart_command] if node.graylog2[:server][:override_restart_command]
+  restart_command node['graylog2']['server']['override_restart_command'] if node['graylog2']['server']['override_restart_command']
 end
 
 file '/etc/init/graylog-server.override' do
   action :delete
-end if node[:platform] == 'ubuntu' && node[:platform_version].to_f >= 9.10
+end if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 9.10
 
-is_master = node.graylog2[:is_master]
-is_master = node.graylog2[:ip_of_master] == node.ipaddress if is_master.nil?
+is_master = node['graylog2']['is_master']
+is_master = node['graylog2']['ip_of_master'] == node.ipaddress if is_master.nil?
 
 template '/etc/graylog/server/server.conf' do
   source 'graylog.server.conf.erb'
   owner 'root'
-  group node.graylog2[:server][:group]
+  group node['graylog2']['server']['group']
   mode 0640
   variables(
     :is_master             => is_master,
     :password_secret       => password_secret,
     :root_password_sha2    => root_password_sha2,
-    :rest_listen_uri       => node.graylog2[:rest][:listen_uri],
-    :rest_transport_uri    => node.graylog2[:rest][:transport_uri],
-    :rest_tls_key_password => secrets['rest_tls_key_password'] || node.graylog2[:rest][:tls_key_password],
-    :web_tls_key_password  => secrets['web_tls_key_password'] || node.graylog2[:web][:tls_key_password],
-    :mongodb_uri           => secrets['mongodb_uri'] || node.graylog2[:mongodb][:uri],
-    :transport_email_auth_password => secrets['transport_email_auth_password'] || node.graylog2[:transport_email_auth_password]
+    :rest_listen_uri       => node['graylog2']['rest']['listen_uri'],
+    :rest_transport_uri    => node['graylog2']['rest']['transport_uri'],
+    :rest_tls_key_password => secrets['rest_tls_key_password'] || node['graylog2']['rest']['tls_key_password'],
+    :web_tls_key_password  => secrets['web_tls_key_password'] || node['graylog2']['web']['tls_key_password'],
+    :mongodb_uri           => secrets['mongodb_uri'] || node['graylog2']['mongodb']['uri'],
+    :transport_email_auth_password => secrets['transport_email_auth_password'] || node['graylog2']['transport_email_auth_password']
   )
-  notifies :restart, 'service[graylog-server]', node.graylog2[:restart].to_sym
+  notifies :restart, 'service[graylog-server]', node['graylog2']['restart'].to_sym
 end
 
 if platform_family?('debian')
@@ -89,21 +89,21 @@ template args_file do
   source 'graylog.server.default.erb'
   owner 'root'
   mode 0644
-  notifies :restart, 'service[graylog-server]', node.graylog2[:restart].to_sym
+  notifies :restart, 'service[graylog-server]', node['graylog2']['restart'].to_sym
 end
 
 template '/etc/graylog/server/log4j2.xml' do
   source 'graylog.server.log4j2.xml.erb'
   owner 'root'
-  group node.graylog2[:server][:group]
+  group node['graylog2']['server']['group']
   mode 0640
-  notifies :restart, 'service[graylog-server]', node.graylog2[:restart].to_sym
+  notifies :restart, 'service[graylog-server]', node['graylog2']['restart'].to_sym
 end
 
 template '/etc/graylog/server/graylog-elasticsearch.yml' do
   source 'graylog.server.elasticsearch.yml.erb'
   owner 'root'
-  group node.graylog2[:server][:group]
+  group node['graylog2']['server']['group']
   mode 0640
-  notifies :restart, 'service[graylog-server]', node.graylog2[:restart].to_sym
+  notifies :restart, 'service[graylog-server]', node['graylog2']['restart'].to_sym
 end

--- a/templates/default/graylog.collector-sidecar.yml.erb
+++ b/templates/default/graylog.collector-sidecar.yml.erb
@@ -1,20 +1,20 @@
-server_url: <%= node.graylog2[:sidecar][:server_url] %>
-update_interval: <%= node.graylog2[:sidecar][:update_interval] %>
-tls_skip_verify: <%= node.graylog2[:sidecar][:tls_skip_verify] %>
-send_status: <%= node.graylog2[:sidecar][:send_status] %>
-list_log_files: <%= node.graylog2[:sidecar][:list_log_files] %>
-node_id: <%= node.graylog2[:sidecar][:name] %>
-collector_id: <%= node.graylog2[:sidecar][:id] %>
-log_path: <%= node.graylog2[:sidecar][:log_path] %>
-log_rotation_time: <%= node.graylog2[:sidecar][:log_rotation_time] %>
-log_max_age: <%= node.graylog2[:sidecar][:log_max_age] %>
-tags: <%= node.graylog2[:sidecar][:tags] %>
+server_url: <%= node['graylog2']['sidecar']['server_url'] %>
+update_interval: <%= node['graylog2']['sidecar']['update_interval'] %>
+tls_skip_verify: <%= node['graylog2']['sidecar']['tls_skip_verify'] %>
+send_status: <%= node['graylog2']['sidecar']['send_status'] %>
+list_log_files: <%= node['graylog2']['sidecar']['list_log_files'] %>
+node_id: <%= node['graylog2']['sidecar']['name'] %>
+collector_id: <%= node['graylog2']['sidecar']['id'] %>
+log_path: <%= node['graylog2']['sidecar']['log_path'] %>
+log_rotation_time: <%= node['graylog2']['sidecar']['log_rotation_time'] %>
+log_max_age: <%= node['graylog2']['sidecar']['log_max_age'] %>
+tags: <%= node['graylog2']['sidecar']['tags'] %>
 backends:
     - name: nxlog
-      enabled: <%= node.graylog2[:sidecar][:backends][:nxlog][:enabled] %>
-      binary_path: <%= node.graylog2[:sidecar][:backends][:nxlog][:binary_path] %>
-      configuration_path: <%= node.graylog2[:sidecar][:backends][:nxlog][:configuration_path] %>
+      enabled: <%= node['graylog2']['sidecar']['backends']['nxlog']['enabled'] %>
+      binary_path: <%= node['graylog2']['sidecar']['backends']['nxlog']['binary_path'] %>
+      configuration_path: <%= node['graylog2']['sidecar']['backends']['nxlog']['configuration_path'] %>
     - name: filebeat
-      enabled: <%= node.graylog2[:sidecar][:backends][:filebeat][:enabled] %>
-      binary_path: <%= node.graylog2[:sidecar][:backends][:filebeat][:binary_path] %>
-      configuration_path: <%= node.graylog2[:sidecar][:backends][:filebeat][:configuration_path] %>
+      enabled: <%= node['graylog2']['sidecar']['backends']['filebeat']['enabled'] %>
+      binary_path: <%= node['graylog2']['sidecar']['backends']['filebeat']['binary_path'] %>
+      configuration_path: <%= node['graylog2']['sidecar']['backends']['filebeat']['configuration_path'] %>

--- a/templates/default/graylog.server.conf.erb
+++ b/templates/default/graylog.server.conf.erb
@@ -1,169 +1,169 @@
 # Cluster settings
 <%= config_option 'is_master', @is_master -%>
-<%= config_option 'node_id_file', node.graylog2[:node_id_file] -%>
+<%= config_option 'node_id_file', node['graylog2']['node_id_file'] -%>
 
 # General
-<%= config_option 'disable_sigar', node.graylog2[:disable_sigar] -%>
-<%= config_option 'dashboard_widget_default_cache_time', node.graylog2[:dashboard_widget_default_cache_time] -%>
+<%= config_option 'disable_sigar', node['graylog2']['disable_sigar'] -%>
+<%= config_option 'dashboard_widget_default_cache_time', node['graylog2']['dashboard_widget_default_cache_time'] -%>
 
 # Access secrets
-<%= config_option 'password_secret', @password_secret, enclose: node.graylog2[:password_secret_enclose_char] -%>
-<%= config_option 'root_username', node.graylog2[:root_username] -%>
-<%= config_option 'root_email', node.graylog2[:root_email] -%>
-<%= config_option 'root_timezone', node.graylog2[:root_timezone] -%>
+<%= config_option 'password_secret', @password_secret, enclose: node['graylog2']['password_secret_enclose_char'] -%>
+<%= config_option 'root_username', node['graylog2']['root_username'] -%>
+<%= config_option 'root_email', node['graylog2']['root_email'] -%>
+<%= config_option 'root_timezone', node['graylog2']['root_timezone'] -%>
 <%= config_option 'root_password_sha2', @root_password_sha2 -%>
 
 # Plugins
-<%= config_option 'plugin_dir', node.graylog2[:plugin_dir] -%> 
+<%= config_option 'plugin_dir', node['graylog2']['plugin_dir'] -%> 
 
 # REST interface
 <%= config_option 'rest_listen_uri', @rest_listen_uri -%>
 <%= config_option 'rest_transport_uri', @rest_transport_uri -%>
-<%= config_option 'rest_enable_cors', node.graylog2[:rest][:enable_cors] -%>
-<%= config_option 'rest_enable_gzip', node.graylog2[:rest][:enable_gzip] -%>
-<%= config_option 'rest_enable_tls', node.graylog2[:rest][:enable_tls] -%>
-<%= config_option 'rest_tls_cert_file', node.graylog2[:rest][:tls_cert_file] -%>
-<%= config_option 'rest_tls_key_file', node.graylog2[:rest][:tls_key_file] -%>
+<%= config_option 'rest_enable_cors', node['graylog2']['rest']['enable_cors'] -%>
+<%= config_option 'rest_enable_gzip', node['graylog2']['rest']['enable_gzip'] -%>
+<%= config_option 'rest_enable_tls', node['graylog2']['rest']['enable_tls'] -%>
+<%= config_option 'rest_tls_cert_file', node['graylog2']['rest']['tls_cert_file'] -%>
+<%= config_option 'rest_tls_key_file', node['graylog2']['rest']['tls_key_file'] -%>
 <%= config_option 'rest_tls_key_password', @rest_tls_key_password -%>
-<%= config_option 'rest_max_chunk_size', node.graylog2[:rest][:max_chunk_size] -%>
-<%= config_option 'rest_max_header_size', node.graylog2[:rest][:max_header_size] -%>
-<%= config_option 'rest_max_initial_line_length', node.graylog2[:rest][:max_initial_line_length] -%>
-<%= config_option 'rest_thread_pool_size', node.graylog2[:rest][:thread_pool_size] -%>
-<%= config_option 'rest_worker_threads_max_pool_size', node.graylog2[:rest][:worker_threads_max_pool_size] -%>
+<%= config_option 'rest_max_chunk_size', node['graylog2']['rest']['max_chunk_size'] -%>
+<%= config_option 'rest_max_header_size', node['graylog2']['rest']['max_header_size'] -%>
+<%= config_option 'rest_max_initial_line_length', node['graylog2']['rest']['max_initial_line_length'] -%>
+<%= config_option 'rest_thread_pool_size', node['graylog2']['rest']['thread_pool_size'] -%>
+<%= config_option 'rest_worker_threads_max_pool_size', node['graylog2']['rest']['worker_threads_max_pool_size'] -%>
 
 # Proxies
-<%= config_option 'trusted_proxies', node.graylog2[:trusted_proxies] -%>
+<%= config_option 'trusted_proxies', node['graylog2']['trusted_proxies'] -%>
 
 # Web interface
-<%= config_option 'web_enable', node.graylog2[:web][:enable] -%>
-<%= config_option 'web_listen_uri', node.graylog2[:web][:listen_uri] -%>
-<%= config_option 'web_endpoint_uri', node.graylog2[:web][:endpoint_uri] -%>
-<%= config_option 'web_enable_cors', node.graylog2[:web][:enable_cors] -%>
-<%= config_option 'web_enable_gzip', node.graylog2[:web][:enable_gzip] -%>
-<%= config_option 'web_enable_tls', node.graylog2[:web][:enable_tls] -%>
-<%= config_option 'web_tls_cert_file', node.graylog2[:web][:tls_cert_file] -%>
-<%= config_option 'web_tls_key_file', node.graylog2[:web][:tls_key_file] -%>
+<%= config_option 'web_enable', node['graylog2']['web']['enable'] -%>
+<%= config_option 'web_listen_uri', node['graylog2']['web']['listen_uri'] -%>
+<%= config_option 'web_endpoint_uri', node['graylog2']['web']['endpoint_uri'] -%>
+<%= config_option 'web_enable_cors', node['graylog2']['web']['enable_cors'] -%>
+<%= config_option 'web_enable_gzip', node['graylog2']['web']['enable_gzip'] -%>
+<%= config_option 'web_enable_tls', node['graylog2']['web']['enable_tls'] -%>
+<%= config_option 'web_tls_cert_file', node['graylog2']['web']['tls_cert_file'] -%>
+<%= config_option 'web_tls_key_file', node['graylog2']['web']['tls_key_file'] -%>
 <%= config_option 'web_tls_key_password', @web_tls_key_password -%>
-<%= config_option 'web_max_header_size', node.graylog2[:web][:max_header_size] -%>
-<%= config_option 'web_max_initial_line_length', node.graylog2[:web][:max_initial_line_length] -%>
-<%= config_option 'web_thread_pool_size', node.graylog2[:web][:thread_pool_size] -%>
+<%= config_option 'web_max_header_size', node['graylog2']['web']['max_header_size'] -%>
+<%= config_option 'web_max_initial_line_length', node['graylog2']['web']['max_initial_line_length'] -%>
+<%= config_option 'web_thread_pool_size', node['graylog2']['web']['thread_pool_size'] -%>
 
 # Search options
-<%= config_option 'allow_leading_wildcard_searches', node.graylog2[:allow_leading_wildcard_searches] -%>
-<%= config_option 'allow_highlighting', node.graylog2[:allow_highlighting] -%>
+<%= config_option 'allow_leading_wildcard_searches', node['graylog2']['allow_leading_wildcard_searches'] -%>
+<%= config_option 'allow_highlighting', node['graylog2']['allow_highlighting'] -%>
 
 # Elasticsearch
 elasticsearch_node_master = false
 elasticsearch_node_data = false
-<%= config_option 'elasticsearch_http_enabled', node.graylog2[:elasticsearch][:http_enabled] -%>
-<%= config_option 'elasticsearch_config_file', node.graylog2[:elasticsearch][:config_file] -%>
-<%= config_option 'elasticsearch_shards', node.graylog2[:elasticsearch][:shards] -%>
-<%= config_option 'elasticsearch_replicas', node.graylog2[:elasticsearch][:replicas] -%>
-<%= config_option 'elasticsearch_index_prefix', node.graylog2[:elasticsearch][:index_prefix] -%>
-<%= config_option 'elasticsearch_cluster_name', node.graylog2[:elasticsearch][:cluster_name] -%>
-<%= config_option 'elasticsearch_transport_tcp_port', node.graylog2[:elasticsearch][:transport_tcp_port] -%>
-<%= config_option 'elasticsearch_discovery_zen_ping_unicast_hosts', node.graylog2[:elasticsearch][:discovery_zen_ping_unicast_hosts] -%>
-<%= config_option 'elasticsearch_network_host', node.graylog2[:elasticsearch][:network_host] -%>
-<%= config_option 'elasticsearch_network_bind_host', node.graylog2[:elasticsearch][:network_bind_host] -%>
-<%= config_option 'elasticsearch_network_publish_host', node.graylog2[:elasticsearch][:network_publish_host] -%>
-<%= config_option 'elasticsearch_analyzer', node.graylog2[:elasticsearch][:analyzer] -%>
-<%= config_option 'elasticsearch_disable_version_check', node.graylog2[:elasticsearch][:disable_version_check] -%>
-<%= config_option 'elasticsearch_template_name', node.graylog2[:elasticsearch][:template_name] -%>
-<%= config_option 'elasticsearch_node_name_prefix', node.graylog2[:elasticsearch][:node_name_prefix] -%>
-<%= config_option 'output_batch_size', node.graylog2[:elasticsearch][:output_batch_size] -%>
-<%= config_option 'output_flush_interval', node.graylog2[:elasticsearch][:output_flush_interval] -%>
-<%= config_option 'output_fault_count_threshold', node.graylog2[:elasticsearch][:output_fault_count_threshold] -%>
-<%= config_option 'output_fault_penalty_seconds', node.graylog2[:elasticsearch][:output_fault_penalty_seconds] -%>
-<%= config_option 'no_retention', node.graylog2[:no_retention] -%>
-<%= config_option 'disable_index_optimization', node.graylog2[:elasticsearch][:disable_index_optimization] -%>
-<%= config_option 'index_optimization_max_num_segments', node.graylog2[:elasticsearch][:index_optimization_max_num_segments] -%>
-<%= config_option 'index_ranges_cleanup_interval', node.graylog2[:elasticsearch][:index_ranges_cleanup_interval] -%>
-<%= config_option 'elasticsearch_template_name', node.graylog2[:elasticsearch][:template_name] -%>
+<%= config_option 'elasticsearch_http_enabled', node['graylog2']['elasticsearch']['http_enabled'] -%>
+<%= config_option 'elasticsearch_config_file', node['graylog2']['elasticsearch']['config_file'] -%>
+<%= config_option 'elasticsearch_shards', node['graylog2']['elasticsearch']['shards'] -%>
+<%= config_option 'elasticsearch_replicas', node['graylog2']['elasticsearch']['replicas'] -%>
+<%= config_option 'elasticsearch_index_prefix', node['graylog2']['elasticsearch']['index_prefix'] -%>
+<%= config_option 'elasticsearch_cluster_name', node['graylog2']['elasticsearch']['cluster_name'] -%>
+<%= config_option 'elasticsearch_transport_tcp_port', node['graylog2']['elasticsearch']['transport_tcp_port'] -%>
+<%= config_option 'elasticsearch_discovery_zen_ping_unicast_hosts', node['graylog2']['elasticsearch']['discovery_zen_ping_unicast_hosts'] -%>
+<%= config_option 'elasticsearch_network_host', node['graylog2']['elasticsearch']['network_host'] -%>
+<%= config_option 'elasticsearch_network_bind_host', node['graylog2']['elasticsearch']['network_bind_host'] -%>
+<%= config_option 'elasticsearch_network_publish_host', node['graylog2']['elasticsearch']['network_publish_host'] -%>
+<%= config_option 'elasticsearch_analyzer', node['graylog2']['elasticsearch']['analyzer'] -%>
+<%= config_option 'elasticsearch_disable_version_check', node['graylog2']['elasticsearch']['disable_version_check'] -%>
+<%= config_option 'elasticsearch_template_name', node['graylog2']['elasticsearch']['template_name'] -%>
+<%= config_option 'elasticsearch_node_name_prefix', node['graylog2']['elasticsearch']['node_name_prefix'] -%>
+<%= config_option 'output_batch_size', node['graylog2']['elasticsearch']['output_batch_size'] -%>
+<%= config_option 'output_flush_interval', node['graylog2']['elasticsearch']['output_flush_interval'] -%>
+<%= config_option 'output_fault_count_threshold', node['graylog2']['elasticsearch']['output_fault_count_threshold'] -%>
+<%= config_option 'output_fault_penalty_seconds', node['graylog2']['elasticsearch']['output_fault_penalty_seconds'] -%>
+<%= config_option 'no_retention', node['graylog2']['no_retention'] -%>
+<%= config_option 'disable_index_optimization', node['graylog2']['elasticsearch']['disable_index_optimization'] -%>
+<%= config_option 'index_optimization_max_num_segments', node['graylog2']['elasticsearch']['index_optimization_max_num_segments'] -%>
+<%= config_option 'index_ranges_cleanup_interval', node['graylog2']['elasticsearch']['index_ranges_cleanup_interval'] -%>
+<%= config_option 'elasticsearch_template_name', node['graylog2']['elasticsearch']['template_name'] -%>
 
 # Processors
-<%= config_option 'processbuffer_processors', node.graylog2[:processbuffer_processors] -%>
-<%= config_option 'outputbuffer_processors', node.graylog2[:outputbuffer_processors] -%>
-<%= config_option 'async_eventbus_processors', node.graylog2[:async_eventbus_processors] -%>
-<%= config_option 'outputbuffer_processor_keep_alive_time', node.graylog2[:outputbuffer_processor_keep_alive_time] -%>
-<%= config_option 'outputbuffer_processor_threads_core_pool_size', node.graylog2[:outputbuffer_processor_threads_core_pool_size] -%>
-<%= config_option 'outputbuffer_processor_threads_max_pool_size', node.graylog2[:outputbuffer_processor_threads_max_pool_size] -%>
-<%= config_option 'processor_wait_strategy', node.graylog2[:processor_wait_strategy] -%>
-<%= config_option 'udp_recvbuffer_sizes', node.graylog2[:udp_recvbuffer_sizes] -%>
-<%= config_option 'inputbuffer_ring_size', node.graylog2[:inputbuffer_ring_size] -%>
-<%= config_option 'inputbuffer_processors', node.graylog2[:inputbuffer_processors] -%>
-<%= config_option 'inputbuffer_wait_strategy', node.graylog2[:inputbuffer_wait_strategy] -%>
+<%= config_option 'processbuffer_processors', node['graylog2']['processbuffer_processors'] -%>
+<%= config_option 'outputbuffer_processors', node['graylog2']['outputbuffer_processors'] -%>
+<%= config_option 'async_eventbus_processors', node['graylog2']['async_eventbus_processors'] -%>
+<%= config_option 'outputbuffer_processor_keep_alive_time', node['graylog2']['outputbuffer_processor_keep_alive_time'] -%>
+<%= config_option 'outputbuffer_processor_threads_core_pool_size', node['graylog2']['outputbuffer_processor_threads_core_pool_size'] -%>
+<%= config_option 'outputbuffer_processor_threads_max_pool_size', node['graylog2']['outputbuffer_processor_threads_max_pool_size'] -%>
+<%= config_option 'processor_wait_strategy', node['graylog2']['processor_wait_strategy'] -%>
+<%= config_option 'udp_recvbuffer_sizes', node['graylog2']['udp_recvbuffer_sizes'] -%>
+<%= config_option 'inputbuffer_ring_size', node['graylog2']['inputbuffer_ring_size'] -%>
+<%= config_option 'inputbuffer_processors', node['graylog2']['inputbuffer_processors'] -%>
+<%= config_option 'inputbuffer_wait_strategy', node['graylog2']['inputbuffer_wait_strategy'] -%>
 
 # Message journal
-<%= config_option 'message_journal_enabled', node.graylog2[:message_journal_enabled] -%>
-<%= config_option 'message_journal_dir', node.graylog2[:message_journal_dir] -%>
-<%= config_option 'message_journal_max_age', node.graylog2[:message_journal_max_age] -%>
-<%= config_option 'message_journal_max_size', node.graylog2[:message_journal_max_size] -%>
-<%= config_option 'message_journal_flush_age', node.graylog2[:message_journal_flush_age] -%>
-<%= config_option 'message_journal_flush_interval', node.graylog2[:message_journal_flush_interval] -%>
-<%= config_option 'message_journal_segment_age', node.graylog2[:message_journal_segment_age] -%>
-<%= config_option 'message_journal_segment_size', node.graylog2[:message_journal_segment_size] -%>
+<%= config_option 'message_journal_enabled', node['graylog2']['message_journal_enabled'] -%>
+<%= config_option 'message_journal_dir', node['graylog2']['message_journal_dir'] -%>
+<%= config_option 'message_journal_max_age', node['graylog2']['message_journal_max_age'] -%>
+<%= config_option 'message_journal_max_size', node['graylog2']['message_journal_max_size'] -%>
+<%= config_option 'message_journal_flush_age', node['graylog2']['message_journal_flush_age'] -%>
+<%= config_option 'message_journal_flush_interval', node['graylog2']['message_journal_flush_interval'] -%>
+<%= config_option 'message_journal_segment_age', node['graylog2']['message_journal_segment_age'] -%>
+<%= config_option 'message_journal_segment_size', node['graylog2']['message_journal_segment_size'] -%>
 
 # Timeouts
-<%= config_option 'output_module_timeout', node.graylog2[:output_module_timeout] -%>
-<%= config_option 'stale_master_timeout', node.graylog2[:stale_master_timeout] -%>
-<%= config_option 'shutdown_timeout', node.graylog2[:shutdown_timeout] -%>
-<%= config_option 'ldap_connection_timeout', node.graylog2[:ldap_connection_timeout] -%>
-<%= config_option 'http_connect_timeout', node.graylog2[:http_connect_timeout] -%>
-<%= config_option 'http_read_timeout', node.graylog2[:http_read_timeout] -%>
-<%= config_option 'http_write_timeout', node.graylog2[:http_write_timeout] -%>
-<%= config_option 'stream_processing_timeout', node.graylog2[:stream_processing_timeout] -%>
-<%= config_option 'elasticsearch_cluster_discovery_timeout', node.graylog2[:elasticsearch][:cluster_discovery_timeout] -%>
-<%= config_option 'elasticsearch_discovery_initial_state_timeout', node.graylog2[:elasticsearch][:discovery_initial_state_timeout] -%>
-<%= config_option 'elasticsearch_request_timeout', node.graylog2[:elasticsearch][:request_timeout] -%>
+<%= config_option 'output_module_timeout', node['graylog2']['output_module_timeout'] -%>
+<%= config_option 'stale_master_timeout', node['graylog2']['stale_master_timeout'] -%>
+<%= config_option 'shutdown_timeout', node['graylog2']['shutdown_timeout'] -%>
+<%= config_option 'ldap_connection_timeout', node['graylog2']['ldap_connection_timeout'] -%>
+<%= config_option 'http_connect_timeout', node['graylog2']['http_connect_timeout'] -%>
+<%= config_option 'http_read_timeout', node['graylog2']['http_read_timeout'] -%>
+<%= config_option 'http_write_timeout', node['graylog2']['http_write_timeout'] -%>
+<%= config_option 'stream_processing_timeout', node['graylog2']['stream_processing_timeout'] -%>
+<%= config_option 'elasticsearch_cluster_discovery_timeout', node['graylog2']['elasticsearch']['cluster_discovery_timeout'] -%>
+<%= config_option 'elasticsearch_discovery_initial_state_timeout', node['graylog2']['elasticsearch']['discovery_initial_state_timeout'] -%>
+<%= config_option 'elasticsearch_request_timeout', node['graylog2']['elasticsearch']['request_timeout'] -%>
 
 # Ring buffers
-<%= config_option 'ring_size', node.graylog2[:ring_size] -%>
+<%= config_option 'ring_size', node['graylog2']['ring_size'] -%>
 
 # Load balancing
-<%= config_option 'lb_recognition_period_seconds', node.graylog2[:lb_recognition_period_seconds] -%>
+<%= config_option 'lb_recognition_period_seconds', node['graylog2']['lb_recognition_period_seconds'] -%>
 
 # Stream processing
-<%= config_option 'stream_processing_max_faults', node.graylog2[:stream_processing_max_faults] -%>
+<%= config_option 'stream_processing_max_faults', node['graylog2']['stream_processing_max_faults'] -%>
 
 # Intervals
-<%= config_option 'alert_check_interval', node.graylog2[:server][:alert_check_interval] -%>
+<%= config_option 'alert_check_interval', node['graylog2']['server']['alert_check_interval'] -%>
 
 # MongoDB Configuration
 <%= config_option 'mongodb_uri', @mongodb_uri -%>
-<%= config_option 'mongodb_max_connections', node.graylog2[:mongodb][:max_connections] -%>
-<%= config_option 'mongodb_threads_allowed_to_block_multiplier', node.graylog2[:mongodb][:threads_allowed_to_block_multiplier] -%>
+<%= config_option 'mongodb_max_connections', node['graylog2']['mongodb']['max_connections'] -%>
+<%= config_option 'mongodb_threads_allowed_to_block_multiplier', node['graylog2']['mongodb']['threads_allowed_to_block_multiplier'] -%>
 
 # Drools Rule File (Use to rewrite incoming log messages)
 # See: http://docs.graylog.org/en/1.0/pages/drools.html
-<%= config_option 'rules_file', node.graylog2[:rules_file] -%>
+<%= config_option 'rules_file', node['graylog2']['rules_file'] -%>
 
 # Email transport
-<%= config_option 'transport_email_enabled', node.graylog2[:transport_email_enabled] -%>
-<%= config_option 'transport_email_hostname', node.graylog2[:transport_email_hostname] -%>
-<%= config_option 'transport_email_port', node.graylog2[:transport_email_port] -%>
-<%= config_option 'transport_email_use_auth', node.graylog2[:transport_email_use_auth] -%>
-<%= config_option 'transport_email_use_tls', node.graylog2[:transport_email_use_tls] -%>
-<%= config_option 'transport_email_use_ssl', node.graylog2[:transport_email_use_ssl] -%>
-<%= config_option 'transport_email_auth_username', node.graylog2[:transport_email_auth_username] -%>
+<%= config_option 'transport_email_enabled', node['graylog2']['transport_email_enabled'] -%>
+<%= config_option 'transport_email_hostname', node['graylog2']['transport_email_hostname'] -%>
+<%= config_option 'transport_email_port', node['graylog2']['transport_email_port'] -%>
+<%= config_option 'transport_email_use_auth', node['graylog2']['transport_email_use_auth'] -%>
+<%= config_option 'transport_email_use_tls', node['graylog2']['transport_email_use_tls'] -%>
+<%= config_option 'transport_email_use_ssl', node['graylog2']['transport_email_use_ssl'] -%>
+<%= config_option 'transport_email_auth_username', node['graylog2']['transport_email_auth_username'] -%>
 <%= config_option 'transport_email_auth_password', @transport_email_auth_password -%>
-<%= config_option 'transport_email_subject_prefix', node.graylog2[:transport_email_subject_prefix] -%>
-<%= config_option 'transport_email_from_email', node.graylog2[:transport_email_from_email] -%>
-<%= config_option 'transport_email_web_interface_url', node.graylog2[:transport_email_web_interface_url] -%>
+<%= config_option 'transport_email_subject_prefix', node['graylog2']['transport_email_subject_prefix'] -%>
+<%= config_option 'transport_email_from_email', node['graylog2']['transport_email_from_email'] -%>
+<%= config_option 'transport_email_web_interface_url', node['graylog2']['transport_email_web_interface_url'] -%>
 
 # HTTP proxy for outgoing HTTP calls
-<%= config_option 'http_proxy_uri', node.graylog2[:http_proxy_uri] -%>
+<%= config_option 'http_proxy_uri', node['graylog2']['http_proxy_uri'] -%>
 
 # GC
-<%= config_option 'gc_warning_threshold', node.graylog2[:server][:gc_warning_threshold] -%>
+<%= config_option 'gc_warning_threshold', node['graylog2']['server']['gc_warning_threshold'] -%>
 
 # Collector
-<%= config_option 'collector_inactive_threshold ', node.graylog2[:server][:collector_inactive_threshold] -%>
-<%= config_option 'collector_expiration_threshold ', node.graylog2[:server][:collector_expiration_threshold] -%>
+<%= config_option 'collector_inactive_threshold ', node['graylog2']['server']['collector_inactive_threshold'] -%>
+<%= config_option 'collector_expiration_threshold ', node['graylog2']['server']['collector_expiration_threshold'] -%>
 
 # Content packs
-<%= config_option 'content_packs_loader_enabled', node.graylog2[:server][:content_packs_loader_enabled] -%>
-<%= config_option 'content_packs_dir', node.graylog2[:server][:content_packs_dir] -%>
-<%= config_option 'content_packs_auto_load', node.graylog2[:server][:content_packs_auto_load] -%>
+<%= config_option 'content_packs_loader_enabled', node['graylog2']['server']['content_packs_loader_enabled'] -%>
+<%= config_option 'content_packs_dir', node['graylog2']['server']['content_packs_dir'] -%>
+<%= config_option 'content_packs_auto_load', node['graylog2']['server']['content_packs_auto_load'] -%>
 
 # Additional options
-<%= node.graylog2[:server][:additional_options] -%>
+<%= node['graylog2']['server']['additional_options'] -%>

--- a/templates/default/graylog.server.default.erb
+++ b/templates/default/graylog.server.default.erb
@@ -1,17 +1,17 @@
 # Path to the java executable.
-JAVA="<%= node.graylog2[:server][:java_bin] %>"
-JAVA_HOME="<%= node.graylog2[:server][:java_home] %>"
+JAVA="<%= node['graylog2']['server']['java_bin'] %>"
+JAVA_HOME="<%= node['graylog2']['server']['java_home'] %>"
 export JAVA_HOME
 
 # Might be used to adjust the Java heap size. (i.e. "-Xms1024m -Xmx2048m")
-GRAYLOG_SERVER_JAVA_OPTS="<%= node.graylog2[:server][:java_opts] %>"
+GRAYLOG_SERVER_JAVA_OPTS="<%= node['graylog2']['server']['java_opts'] %>"
 
 # Pass some extra args to graylog-server. (i.e. "-d" to enable debug mode)
-GRAYLOG_SERVER_ARGS="<%= node.graylog2[:server][:args] %>"
+GRAYLOG_SERVER_ARGS="<%= node['graylog2']['server']['args'] %>"
 
 # Program that will be used to wrap the graylog-server command. Useful to
 # support programs like authbind.
-GRAYLOG_COMMAND_WRAPPER="<%= node.graylog2[:server][:wrapper] %>"
+GRAYLOG_COMMAND_WRAPPER="<%= node['graylog2']['server']['wrapper'] %>"
 
 # Additional environment variables
-<%= node.graylog2[:server][:additional_env_vars] -%>
+<%= node['graylog2']['server']['additional_env_vars'] -%>

--- a/templates/default/graylog.server.elasticsearch.yml.erb
+++ b/templates/default/graylog.server.elasticsearch.yml.erb
@@ -1,8 +1,8 @@
 # this must be the same as for your elasticsearch cluster
-<%= config_option 'cluster.name', node.graylog2[:elasticsearch][:cluster_name], separator: ': ' -%>
+<%= config_option 'cluster.name', node['graylog2']['elasticsearch']['cluster_name'], separator: ': ' -%>
 
 # you could also leave this out, but makes it easier to identify the graylog2 client instance
-<%= config_option 'node.name', node.graylog2[:elasticsearch][:node_name], separator: ': ', enclose: '"' -%>
+<%= config_option 'node.name', node['graylog2']['elasticsearch']['node_name'], separator: ': ', enclose: '"' -%>
 
 # we don't want the graylog2 client to store any data, or be master node
 node.master: false
@@ -11,10 +11,10 @@ node.data: false
 # you might need to bind to a certain IP address, do that here
 #network.host: 172.24.0.14
 # use a different port if you run multiple elasticsearch nodes on one machine
-<%= config_option 'transport.tcp.port', node.graylog2[:elasticsearch][:transport_tcp_port], separator: ': ' -%>
+<%= config_option 'transport.tcp.port', node['graylog2']['elasticsearch']['transport_tcp_port'], separator: ': ' -%>
 
 # we don't need to run the embedded HTTP server here
-<%= config_option 'http.enabled', node.graylog2[:elasticsearch][:http_enabled], separator: ': ' -%>
+<%= config_option 'http.enabled', node['graylog2']['elasticsearch']['http_enabled'], separator: ': ' -%>
 
 # adapt these for discovery to work in your network! multicast can be tricky
 #discovery.zen.ping.multicast.address: 172.24.0.14
@@ -44,7 +44,7 @@ node.data: false
 # Unicast discovery allows to explicitly control which nodes will be used
 # to discover the cluster. It can be used when multicast is not present,
 # or to restrict the cluster communication-wise.
-<%= config_option 'discovery.zen.ping.unicast.hosts', node.graylog2[:elasticsearch][:discovery_zen_ping_unicast_hosts], separator: ': ' -%>
+<%= config_option 'discovery.zen.ping.unicast.hosts', node['graylog2']['elasticsearch']['discovery_zen_ping_unicast_hosts'], separator: ': ' -%>
 
 # EC2 discovery allows to use AWS EC2 API in order to perform discovery.
 #

--- a/templates/default/graylog.server.log4j2.xml.erb
+++ b/templates/default/graylog.server.log4j2.xml.erb
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration packages="org.graylog2.log4j" shutdownHook="disable">
     <Appenders>
-        <RollingFile name="graylog-rolling-file" fileName="<%= node.graylog2[:server][:log_file] %>"
-                 filePattern="<%= node.graylog2[:server][:log_file] %>.%i.gz">
-            <PatternLayout pattern="<%= node.graylog2[:server][:log_pattern] %>"/>
+        <RollingFile name="graylog-rolling-file" fileName="<%= node['graylog2']['server']['log_file'] %>"
+                 filePattern="<%= node['graylog2']['server']['log_file'] %>.%i.gz">
+            <PatternLayout pattern="<%= node['graylog2']['server']['log_pattern'] %>"/>
             <Policies>
-              <SizeBasedTriggeringPolicy size="<%= node.graylog2[:server][:log_max_size] %>"/>
+              <SizeBasedTriggeringPolicy size="<%= node['graylog2']['server']['log_max_size'] %>"/>
             </Policies>
-            <DefaultRolloverStrategy max="<%= node.graylog2[:server][:log_max_index] %>" fileIndex="min"/>
+            <DefaultRolloverStrategy max="<%= node['graylog2']['server']['log_max_index'] %>" fileIndex="min"/>
         </RollingFile>
 
         <!-- Internal Graylog log appender. Please do not disable. This makes internal log messages available via REST calls. -->
@@ -15,7 +15,7 @@
     </Appenders>
     <Loggers>
         <!-- Application Loggers -->
-        <Logger name="org.graylog2" level="<%= node.graylog2[:server][:log_level_application] %>"/>
+        <Logger name="org.graylog2" level="<%= node['graylog2']['server']['log_level_application'] %>"/>
         <Logger name="com.github.joschi.jadconfig" level="warn"/>
         <!-- this emits a harmless warning for ActiveDirectory every time which we can't work around :( -->
         <Logger name="org.apache.directory.api.ldap.model.message.BindRequestImpl" level="error"/>
@@ -32,7 +32,7 @@
         <Logger name="kafka.log.OffsetIndex" level="warn"/>
         <!-- Silence useless session validation messages -->
         <Logger name="org.apache.shiro.session.mgt.AbstractValidatingSessionManager" level="warn"/>
-        <Root level="<%= node.graylog2[:server][:log_level_root]%>">
+        <Root level="<%= node['graylog2']['server']['log_level_root']%>">
             <AppenderRef ref="graylog-internal-logs"/>
             <AppenderRef ref="graylog-rolling-file"/>
         </Root>


### PR DESCRIPTION
This fixes a huge number of deprecation warning for node attribute access.

  WARN: method access to node attributes (node.foo.bar) is deprecated and
  will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"])

It also makes node attribute access consistent with current style guidelines
for foodcritic rules: FC001, FC019