### PR TITLE
Further cleanup of node method use

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -143,7 +143,7 @@ default['graylog2']['elasticsearch']['request_timeout']                 = '1m'
 default['graylog2']['server']['alert_check_interval'] = nil
 
 # Cluster
-default['graylog2']['ip_of_master']                  = node.ipaddress
+default['graylog2']['ip_of_master']                  = node['ipaddress']
 default['graylog2']['lb_recognition_period_seconds'] = 3
 
 # Email transport

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -56,7 +56,7 @@ file '/etc/init/graylog-server.override' do
 end if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 9.10
 
 is_master = node['graylog2']['is_master']
-is_master = node['graylog2']['ip_of_master'] == node.ipaddress if is_master.nil?
+is_master = node['graylog2']['ip_of_master'] == node['ipaddress'] if is_master.nil?
 
 template '/etc/graylog/server/server.conf' do
   source 'graylog.server.conf.erb'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -14,7 +14,7 @@ raise('No root_password_sha2 set, either set it via an attribute or in the encry
 if node['graylog2']['elasticsearch']['unicast_search_query'] && node['graylog2']['elasticsearch']['search_node_attribute']
   nodes = search_for_nodes(node['graylog2']['elasticsearch']['unicast_search_query'], node['graylog2']['elasticsearch']['search_node_attribute'])
   Chef::Log.debug("Found elasticsearch nodes at #{nodes.join(', ').inspect}")
-  node.set['graylog2']['elasticsearch']['discovery_zen_ping_unicast_hosts'] = nodes.map { |ip| ip + ':9300' }.join(',')
+  node.default['graylog2']['elasticsearch']['discovery_zen_ping_unicast_hosts'] = nodes.map { |ip| ip + ':9300' }.join(',')
 end
 
 package 'tzdata-java' if node['graylog2']['server']['install_tzdata_java']

--- a/spec/unit/recipes/collector_sidecar_spec.rb
+++ b/spec/unit/recipes/collector_sidecar_spec.rb
@@ -8,8 +8,8 @@ describe 'graylog2::collector_sidecar' do
         version: '14.04',
         file_cache_path: '/tmp'
       ) do |node|
-        node.set['graylog2']['sidecar']['version'] = '0.0.8'
-        node.set['graylog2']['sidecar']['build'] = 1
+        node.normal['graylog2']['sidecar']['version'] = '0.0.8'
+        node.normal['graylog2']['sidecar']['build'] = 1
       end.converge('graylog2::collector_sidecar')
     end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -7,9 +7,9 @@ describe 'graylog2::default' do
         platform: 'ubuntu',
         version: '14.04'
       ) do |node|
-        node.set['java']['jdk_version'] = '8'
-        node.set['graylog2']['major_version'] = '2.0'
-        node.set['graylog2']['repo_version'] = '1-1'
+        node.normal['java']['jdk_version'] = '8'
+        node.normal['graylog2']['major_version'] = '2.0'
+        node.normal['graylog2']['repo_version'] = '1-1'
       end.converge('graylog2::default')
     end
 
@@ -28,9 +28,9 @@ describe 'graylog2::default' do
         platform: 'centos',
         version: '6.7'
       ) do |node|
-        node.set['java']['jdk_version'] = '8'
-        node.set['graylog2']['major_version'] = '2.0'
-        node.set['graylog2']['repo_version'] = '1-1'
+        node.normal['java']['jdk_version'] = '8'
+        node.normal['graylog2']['major_version'] = '2.0'
+        node.normal['graylog2']['repo_version'] = '1-1'
       end.converge('graylog2::default')
     end
 
@@ -42,7 +42,7 @@ describe 'graylog2::default' do
   context 'when the Java installation is not compatible' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
-        node.set['java']['jdk_version'] = '7'
+        node.normal['java']['jdk_version'] = '7'
       end.converge('graylog2::default')
     end
 

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -17,8 +17,8 @@ describe 'graylog2::server' do
         platform: 'ubuntu',
         version: '14.04'
       ) do |node|
-        node.set['graylog2']['password_secret'] = 'password_hash'
-        node.set['graylog2']['root_password_sha2'] = 'salt'
+        node.default['graylog2']['password_secret'] = 'password_hash'
+        node.default['graylog2']['root_password_sha2'] = 'salt'
       end.converge('graylog2::server')
     end
 
@@ -58,8 +58,8 @@ describe 'graylog2::server' do
         platform: 'centos',
         version: '6.7'
       ) do |node|
-        node.set['graylog2']['password_secret'] = 'password_hash'
-        node.set['graylog2']['root_password_sha2'] = 'salt'
+        node.default['graylog2']['password_secret'] = 'password_hash'
+        node.default['graylog2']['root_password_sha2'] = 'salt'
       end.converge('graylog2::server')
     end
 


### PR DESCRIPTION
Some more cleanup of method access to remove warnings.

A little unsure if `.default` is what you want in 066b6a2, depends on if you need the discovered value for `discovery_zen_ping_unicast_hosts` to persist in the node object, but this way seems to work for me.

I also left the library code that provides `search_for_nodes` alone for now.