### PR TITLE
Fixing service file check to support systemd

### DIFF
--- a/recipes/collector_sidecar.rb
+++ b/recipes/collector_sidecar.rb
@@ -47,9 +47,9 @@ execute 'install service graylog-collector-sidecar' do
   notifies :restart, 'service[collector-sidecar]'
   case node['platform']
   when 'ubuntu'
-    not_if { File.exists?('/etc/systemd/system/collector-sidecar.service') || File.exists?('/etc/init/collector-sidecar.conf') }
+    not_if { File.exists?('/etc/systemd/system/collector-sidecar.service') || File.exists?('/etc/init/collector-sidecar.conf')}
   when 'debian', 'redhat', 'centos'
-    not_if { File.exists?('/etc/systemd/system/collector-sidecar.service') ||  File.exists?('/etc/init.d/collector-sidecar') }
+    not_if { File.exists?('/etc/systemd/system/collector-sidecar.service') || File.exists?('/etc/init.d/collector-sidecar')}
   end
 end
 

--- a/recipes/collector_sidecar.rb
+++ b/recipes/collector_sidecar.rb
@@ -47,9 +47,9 @@ execute 'install service graylog-collector-sidecar' do
   notifies :restart, 'service[collector-sidecar]'
   case node['platform']
   when 'ubuntu'
-    not_if { File.exists?('/etc/systemd/system/collector-sidecar.service') || File.exists?('/etc/init/collector-sidecar.conf')}
+    not_if { File.exist?('/etc/systemd/system/collector-sidecar.service') || File.exist?('/etc/init/collector-sidecar.conf') }
   when 'debian', 'redhat', 'centos'
-    not_if { File.exists?('/etc/systemd/system/collector-sidecar.service') || File.exists?('/etc/init.d/collector-sidecar')}
+    not_if { File.exist?('/etc/systemd/system/collector-sidecar.service') || File.exist?('/etc/init.d/collector-sidecar') }
   end
 end
 


### PR DESCRIPTION
Sidecar collector setup fails on repeat runs because of invalid check for systemd type services on Ubuntu 16.04+ and [RHEL|OEL|CENTOS]7+ 

There may be a better way to do this, but it worked for me. Running on OEL6-7, CentOS7+, Ubuntu 14.04, and Ubuntu 16.04.

Apologies on the messy pull request.