### PR TITLE
Make cache_path configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -211,6 +211,7 @@ default['graylog2']['sidecar']['log_path']                       = '/var/log/gra
 default['graylog2']['sidecar']['log_rotation_time']              = 86400
 default['graylog2']['sidecar']['log_max_age']                    = 604800
 default['graylog2']['sidecar']['tags']                           = 'linux' # multiple tags '[tag1, tag2, tag3]'
+default['graylog2']['sidecar']['cache_path']                     = '/var/cache/graylog/collector-sidecar'
 default['graylog2']['sidecar']['backends']['nxlog']['enabled']               = false
 default['graylog2']['sidecar']['backends']['nxlog']['binary_path']           = '/usr/bin/nxlog'
 default['graylog2']['sidecar']['backends']['nxlog']['configuration_path']    = '/etc/graylog/collector-sidecar/generated/nxlog.conf'

--- a/templates/default/graylog.collector-sidecar.yml.erb
+++ b/templates/default/graylog.collector-sidecar.yml.erb
@@ -5,6 +5,7 @@ send_status: <%= node['graylog2']['sidecar']['send_status'] %>
 list_log_files: <%= node['graylog2']['sidecar']['list_log_files'] %>
 node_id: <%= node['graylog2']['sidecar']['name'] %>
 collector_id: <%= node['graylog2']['sidecar']['id'] %>
+cache_path: <%= node['graylog2']['sidecar']['cache_path'] %>
 log_path: <%= node['graylog2']['sidecar']['log_path'] %>
 log_rotation_time: <%= node['graylog2']['sidecar']['log_rotation_time'] %>
 log_max_age: <%= node['graylog2']['sidecar']['log_max_age'] %>


### PR DESCRIPTION
`cache_path` wasn't included in the original template but is included when using the installer/packages.  This updates the template to be in line with a standard package installation.