### PR TITLE
Adding extra network example config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ run_list "recipe[java]",
 
 Keep in mind that Graylog needs Elasticsearch 2.x, what can be installed with the Elasticsearch cookbook version < 3.0.0
 
+### Running behind a NAT'ed public IP
+
+If you are running Graylog behind a NAT, you will need to set:
+
+```
+"graylog2":{
+    "rest":{
+      "transport_uri": "http://<public facing IP>:12900/",
+      "listen_uri": "http://0.0.0.0:12900/"
+    }
+  },
+```
+
+See [graylog docs](http://docs.graylog.org/en/2.2/pages/configuration/web_interface.html#single-or-separate-listeners-for-web-interface-and-rest-api) for more info.
+
 ### Attributes
 Graylog runs currently with Java 8. To install the correct version set this attribute:
 


### PR DESCRIPTION
I've found that this piece of config was very useful, it might save a good few hours for users deploying to remote machines behind a NAT. Please add more detail if you can, I have mainly figured this out by trial and error. I know there is an alternative way to set it up by using the same port, but it didn't work in my case.