### PR TITLE
Check api

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -2,4 +2,8 @@ if defined?(ChefSpec)
   def create_admin_token(token)
     ChefSpec::Matchers::ResourceMatcher.new(:graylog2_admin_token, :create, token)
   end
+
+  def check_api(name)
+    ChefSpec::Matchers::ResourceMatcher.new(:graylog2_check_api, :check, name)
+  end
 end

--- a/recipes/api.rb
+++ b/recipes/api.rb
@@ -13,3 +13,5 @@ end
 token = node['graylog2']['rest']['admin_access_token']
 raise 'You should set admin_access_token attribute' if token.nil?
 graylog2_admin_token token
+
+graylog2_check_api node['graylog2']['rest']['listen_uri']

--- a/resources/check_api.rb
+++ b/resources/check_api.rb
@@ -1,0 +1,32 @@
+property :uri, String, name_property: true
+property :token, String
+
+default_action :check
+
+action :check do
+  require 'graylogapi'
+
+  log 'Wait until the Graylog2 API is ready' do
+    level :info
+  end
+
+  url = new_resource.uri || node['graylog2']['rest']['listen_uri']
+  token = new_resource.token || node['graylog2']['rest']['admin_access_token']
+  retries = node['graylog2']['api_client_timeout'] || 300
+
+  graylogapi = GraylogAPI.new(base_url: url, token: token)
+
+  begin
+    graylogapi.client.request(:get, '/')
+  rescue
+    raise "Can't connect to the Graylog2 API #{uri}" if retries <= 0
+
+    retries -= 1
+    sleep 1
+    retry
+  end
+
+  log 'Graylog2 API available, resume provision' do
+    level :info
+  end
+end

--- a/spec/unit/recipes/api_spec.rb
+++ b/spec/unit/recipes/api_spec.rb
@@ -23,6 +23,10 @@ describe 'graylog2::api' do
     it 'set token' do
       expect(chef_run).to create_admin_token 'testtoken'
     end
+
+    it 'check api' do
+      expect(chef_run).to check_api 'http://0.0.0.0:9000/api/'
+    end
   end
 
   context 'when the recipe run on a Ubuntu system' do
@@ -30,6 +34,8 @@ describe 'graylog2::api' do
 
     let(:chef_run) do
       runner.node.normal['graylog2']['rest']['admin_access_token'] = 'testtoken'
+      runner.node.normal['graylog2']['rest']['listen_url'] = 'http://0.0.0.0:9000/api/'
+
       runner.converge('graylog2::api')
     end
 
@@ -45,6 +51,8 @@ describe 'graylog2::api' do
 
     let(:chef_run) do
       runner.node.normal['graylog2']['rest']['admin_access_token'] = 'testtoken'
+      runner.node.normal['graylog2']['rest']['listen_url'] = 'http://0.0.0.0:9000/api/'
+
       runner.converge('graylog2::api')
     end
 

--- a/test/integration/openjdk/serverspec/api_spec.rb
+++ b/test/integration/openjdk/serverspec/api_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe command('timeout 60 bash -c "until curl -s -H \'Accept: application/json\' -u F3DenL9HXW12KECdLmrfQ8HNGW4zwbwlJSyo7PxlsgHvgeay5F3tQhnoH6T2G7X3iiy2bcYPClsjCWi1PIY48sCSSyoW4H64:token http://127.0.0.1:9000/api/dashboards; do sleep 1; done"') do
+describe command('bash -c "until curl -s -H \'Accept: application/json\' -u F3DenL9HXW12KECdLmrfQ8HNGW4zwbwlJSyo7PxlsgHvgeay5F3tQhnoH6T2G7X3iiy2bcYPClsjCWi1PIY48sCSSyoW4H64:token http://127.0.0.1:9000/api/dashboards; do sleep 1; done"') do
   its(:stdout) { should contain 'dashboards' }
 end

--- a/test/integration/oracle/serverspec/api_spec.rb
+++ b/test/integration/oracle/serverspec/api_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe command('timeout 60 bash -c "until curl -s -H \'Accept: application/json\' -u F3DenL9HXW12KECdLmrfQ8HNGW4zwbwlJSyo7PxlsgHvgeay5F3tQhnoH6T2G7X3iiy2bcYPClsjCWi1PIY48sCSSyoW4H64:token http://127.0.0.1:9000/api/dashboards; do sleep 1; done"') do
+describe command('bash -c "until curl -s -H \'Accept: application/json\' -u F3DenL9HXW12KECdLmrfQ8HNGW4zwbwlJSyo7PxlsgHvgeay5F3tQhnoH6T2G7X3iiy2bcYPClsjCWi1PIY48sCSSyoW4H64:token http://127.0.0.1:9000/api/dashboards; do sleep 1; done"') do
   its(:stdout) { should contain 'dashboards' }
 end


### PR DESCRIPTION
Custom resource `graylog2_check_api ` for checking API.

Properties:
* uri -- API endpoint
* token -- User's authorization token

Example:
```
graylog2_check_api 'http://127.0.0.1:9000/api' do
    token: '2318530845fhls'
end
```