### PR TITLE
Input resource

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -77,6 +77,7 @@ suites:
       - recipe[graylog2::collector_sidecar]
       - recipe[graylog2::authbind]
       - recipe[graylog2::api]
+      - recipe[api_resources_test]
   - name: openjdk
     attributes:
       machine_fqdn: graylog.local

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -67,16 +67,16 @@ suites:
         cluster:
           name: "graylog"
     run_list:
-      # - recipe[fqdn]
-      # - recipe[curl]
-      # - recipe[mongodb]
-      # - recipe[java]
-      # - recipe[elasticsearch_test]
-      # - recipe[graylog2]
-      # - recipe[graylog2::server]
-      # - recipe[graylog2::collector_sidecar]
-      # - recipe[graylog2::authbind]
-      # - recipe[graylog2::api]
+      - recipe[fqdn]
+      - recipe[curl]
+      - recipe[mongodb]
+      - recipe[java]
+      - recipe[elasticsearch_test]
+      - recipe[graylog2]
+      - recipe[graylog2::server]
+      - recipe[graylog2::collector_sidecar]
+      - recipe[graylog2::authbind]
+      - recipe[graylog2::api]
       - recipe[api_resources_test]
   - name: openjdk
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -67,16 +67,16 @@ suites:
         cluster:
           name: "graylog"
     run_list:
-      - recipe[fqdn]
-      - recipe[curl]
-      - recipe[mongodb]
-      - recipe[java]
-      - recipe[elasticsearch_test]
-      - recipe[graylog2]
-      - recipe[graylog2::server]
-      - recipe[graylog2::collector_sidecar]
-      - recipe[graylog2::authbind]
-      - recipe[graylog2::api]
+      # - recipe[fqdn]
+      # - recipe[curl]
+      # - recipe[mongodb]
+      # - recipe[java]
+      # - recipe[elasticsearch_test]
+      # - recipe[graylog2]
+      # - recipe[graylog2::server]
+      # - recipe[graylog2::collector_sidecar]
+      # - recipe[graylog2::authbind]
+      # - recipe[graylog2::api]
       - recipe[api_resources_test]
   - name: openjdk
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -12,4 +12,5 @@ group :integration do
 
   cookbook "apt_backports", :path => "./test/fixtures/cookbooks/apt_backports"
   cookbook "elasticsearch_test", :path => "./test/fixtures/cookbooks/elasticsearch_test"
+  cookbook "api_resources_test", :path => "./test/fixtures/cookbooks/api_resources_test"
 end

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,4 +1,6 @@
 DEPENDENCIES
+  api_resources_test
+    path: test/fixtures/cookbooks/api_resources_test
   apt
   apt_backports
     path: test/fixtures/cookbooks/apt_backports
@@ -14,6 +16,8 @@ DEPENDENCIES
   mongodb
 
 GRAPH
+  api_resources_test (0.0.1)
+    graylog2 (>= 0.0.0)
   apt (4.0.1)
     compat_resource (>= 12.10)
   apt_backports (0.0.1)

--- a/libraries/api_helper.rb
+++ b/libraries/api_helper.rb
@@ -6,5 +6,12 @@ module Extensions
         token: new_resource.api_token || node['graylog2']['rest']['admin_access_token']
       }
     end
+
+    def keys_to_symbols(hash)
+      hash.each_with_object({}) do |(k, v), new_hash|
+        new_hash[k.to_sym] = v
+        new_hash
+      end
+    end
   end
 end

--- a/libraries/api_helper.rb
+++ b/libraries/api_helper.rb
@@ -1,0 +1,10 @@
+module Extensions
+  module ApiHelper
+    def auth_params(new_resource)
+      {
+        base_url: new_resource.api_uri || node['graylog2']['rest']['listen_uri'],
+        token: new_resource.api_token || node['graylog2']['rest']['admin_access_token']
+      }
+    end
+  end
+end

--- a/resources/check_api.rb
+++ b/resources/check_api.rb
@@ -1,20 +1,19 @@
-property :uri, String, name_property: true
-property :token, String
+property :api_uri, String, nil], name_property: true
+property :api_token, [String, nil], default: nil
 
 default_action :check
 
 action :check do
   require 'graylogapi'
+  extend Extensions::ApiHelper
 
   log 'Wait until the Graylog2 API is ready' do
     level :info
   end
 
-  url = new_resource.uri || node['graylog2']['rest']['listen_uri']
-  token = new_resource.token || node['graylog2']['rest']['admin_access_token']
   retries = node['graylog2']['api_client_timeout'] || 300
 
-  graylogapi = GraylogAPI.new(base_url: url, token: token)
+  graylogapi = GraylogAPI.new(auth_params(new_resource))
 
   begin
     graylogapi.client.request(:get, '/')

--- a/resources/check_api.rb
+++ b/resources/check_api.rb
@@ -1,20 +1,19 @@
-property :uri, String, name_property: true
-property :token, String
+property :api_uri, [String, nil], name_property: true
+property :api_token, [String, nil], default: nil
 
 default_action :check
 
 action :check do
   require 'graylogapi'
+  extend Extensions::ApiHelper
 
   log 'Wait until the Graylog2 API is ready' do
     level :info
   end
 
-  url = new_resource.uri || node['graylog2']['rest']['listen_uri']
-  token = new_resource.token || node['graylog2']['rest']['admin_access_token']
   retries = node['graylog2']['api_client_timeout'] || 300
 
-  graylogapi = GraylogAPI.new(base_url: url, token: token)
+  graylogapi = GraylogAPI.new(auth_params(new_resource))
 
   begin
     graylogapi.client.request(:get, '/')

--- a/resources/input.rb
+++ b/resources/input.rb
@@ -1,8 +1,7 @@
 property :title, String, name_property: true, required: true
 property :hostname, [String, nil], default: nil
 property :type, String, required: true
-property :address, String, required: true
-property :port, Integer, required: true
+property :settings, Hash, required: true
 
 # api auth settings
 property :api_uri, [String, nil], default: nil
@@ -20,11 +19,7 @@ action :create do
     title: new_resource.title,
     global: new_resource.hostname.nil?,
     node: new_resource.hostname.nil? ? nil : new_resource.hostname,
-    configuration: {
-      bind_address: new_resource.address,
-      port: new_resource.port
-    }
-  }
+  }.merge(new_resource.settings)
 
   options[:type] =
     begin

--- a/resources/input.rb
+++ b/resources/input.rb
@@ -1,0 +1,43 @@
+property :title, String, name_property: true, required: true
+property :hostname, [String, nil], default: nil
+property :type, String, required: true
+property :address, String, required: true
+property :port, Integer, required: true
+
+# api auth settings
+property :api_uri, [String, nil], default: nil
+property :api_token, [String, nil], default: nil
+
+default_action :create
+
+action :create do
+  require 'graylogapi'
+  extend Extensions::ApiHelper
+
+  graylogapi = GraylogAPI.new(auth_params(new_resource))
+
+  options = {
+    title: new_resource.title,
+    global: new_resource.hostname.nil?,
+    node: new_resource.hostname.nil? ? nil : new_resource.hostname,
+    configuration: {
+      bind_address: new_resource.address,
+      port: new_resource.port
+    }
+  }
+
+  options[:type] =
+    begin
+      graylogapi.system.inputs.types.name_to_type(new_resource.type)
+    rescue
+      raise "Can't find inpyt type: #{new_resource.type}"
+    end
+
+  response = graylogapi.system.inputs.create(options)
+
+  log 'Can`t create input' do
+    message response.body.to_s
+    level :fatal
+    only_if { response.fail? }
+  end
+end

--- a/resources/input.rb
+++ b/resources/input.rb
@@ -59,6 +59,22 @@ action :create do
   end
 end
 
+action :delete do
+  require 'graylogapi'
+  extend Extensions::ApiHelper
+  graylogapi = GraylogAPI.new(auth_params(new_resource))
+
+  input = graylogapi.system.inputs.all['inputs'].find { |i| i['title'] == 'global beats input' }
+
+  if input.nil?
+    log 'Input already deleted' do
+      level :info
+    end
+  else
+    graylogapi.system.inputs.delete(input['id'])
+  end
+end
+
 def hostname_to_node_id(graylogapi, hostname)
   return nil if hostname.nil?
 

--- a/resources/input.rb
+++ b/resources/input.rb
@@ -9,25 +9,53 @@ property :api_token, [String, nil], default: nil
 
 default_action :create
 
-action :create do
+# this field use for update request
+attr_reader :input_id
+
+load_current_value do
   require 'graylogapi'
   extend Extensions::ApiHelper
+  graylogapi = GraylogAPI.new(auth_params(self))
 
-  graylogapi = GraylogAPI.new(auth_params(new_resource))
+  inputs = graylogapi.system.inputs.all['inputs']
+  current_input = inputs.find { |i| i['title'] == title }
 
-  options = {
-    title: new_resource.title,
-    global: new_resource.hostname.nil?,
-    node: hostname_to_node_id(graylogapi, new_resource.hostname),
-    type: type_to_type_id(graylogapi, new_resource.type),
-  }.merge(new_resource.settings)
+  current_value_does_not_exist! if current_input.nil?
 
-  response = graylogapi.system.inputs.create(options)
+  title current_input['title']
+  type type_id_to_type(graylogapi, current_input['type'])
+  hostname current_input['global'] ? nil : node_id_to_hostname(graylogapi, current_input['node'])
+  settings(configuration: keys_to_symbols(current_input['attributes']))
 
-  log 'Can`t create input' do
-    message response.body.to_s
-    level :fatal
-    only_if { response.fail? }
+  # this use for update request
+  @input_id = current_input['id']
+end
+
+action :create do
+  converge_if_changed do
+    require 'graylogapi'
+    extend Extensions::ApiHelper
+    graylogapi = GraylogAPI.new(auth_params(new_resource))
+
+    options = {
+      title: new_resource.title,
+      global: new_resource.hostname.nil?,
+      node: hostname_to_node_id(graylogapi, new_resource.hostname),
+      type: type_to_type_id(graylogapi, new_resource.type),
+    }.merge(new_resource.settings)
+
+    response =
+      if current_resource.nil?
+        graylogapi.system.inputs.create(options)
+      else
+        graylogapi.system.inputs.update(current_resource.input_id, options)
+      end
+
+    log 'Can`t create input' do
+      message response.body.to_s
+      level :fatal
+      only_if { response.fail? }
+    end
   end
 end
 
@@ -43,6 +71,25 @@ def hostname_to_node_id(graylogapi, hostname)
   node_id['node_id']
 end
 
+def node_id_to_hostname(graylogapi, node_id)
+  graylogapi.system.cluster.nodes['nodes'].find do |node|
+    node['node_id'] == node_id
+  end['hostname']
+end
+
 def type_to_type_id(graylogapi, type)
   graylogapi.system.inputs.types.name_to_type(type)
+end
+
+def type_id_to_type(graylogapi, type_id)
+  graylogapi.system.inputs.types.all.body.find do |_, type|
+    type['type'].casecmp(type_id).zero?
+  end.last['name']
+end
+
+def keys_to_symbols(hash)
+  hash.each_with_object({}) do |(k, v), new_hash|
+    new_hash[k.to_sym] = v
+    new_hash
+  end
 end

--- a/resources/input.rb
+++ b/resources/input.rb
@@ -33,7 +33,7 @@ action :create do
     else
       begin
         graylogapi.system.cluster.nodes['nodes'].find do |i|
-          i['hostname'] == 'graylog.local'
+          i['hostname'] == new_resource.hostname
         end['node_id']
       rescue
         raise "Can't find node with hostname: #{new_resource.hostname}"

--- a/test/fixtures/cookbooks/api_resources_test/metadata.rb
+++ b/test/fixtures/cookbooks/api_resources_test/metadata.rb
@@ -1,0 +1,9 @@
+name             'api_resources_test'
+maintainer       'Marius Sturm'
+maintainer_email 'marius.sturm@graylog.com'
+license          'Apache 2.0'
+description      'A wrapper cookbook used for Graylog testing'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.0.1'
+
+depends 'graylog2'

--- a/test/fixtures/cookbooks/api_resources_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/api_resources_test/recipes/default.rb
@@ -1,12 +1,10 @@
 graylog2_input 'global beats input' do
   type 'Beats'
-  address '0.0.0.0'
-  port 5014
+  settings(configuration: { bind_address: '0.0.0.0', port: 5044 })
 end
 
 graylog2_input 'local syslog tcp input' do
   hostname 'f594fbd6-9277-4e8f-9eba-e8d318f41872'
   type 'Syslog TCP'
-  address '0.0.0.0'
-  port 5015
+  settings(configuration: { bind_address: '0.0.0.0', port: 5015 })
 end

--- a/test/fixtures/cookbooks/api_resources_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/api_resources_test/recipes/default.rb
@@ -1,0 +1,12 @@
+graylog2_input 'global beats input' do
+  type 'Beats'
+  address '0.0.0.0'
+  port 5014
+end
+
+graylog2_input 'local syslog tcp input' do
+  hostname 'f594fbd6-9277-4e8f-9eba-e8d318f41872'
+  type 'Syslog TCP'
+  address '0.0.0.0'
+  port 5015
+end

--- a/test/fixtures/cookbooks/api_resources_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/api_resources_test/recipes/default.rb
@@ -4,7 +4,7 @@ graylog2_input 'global beats input' do
 end
 
 graylog2_input 'local syslog tcp input' do
-  hostname 'f594fbd6-9277-4e8f-9eba-e8d318f41872'
+  hostname 'graylog.local'
   type 'Syslog TCP'
   settings(configuration: { bind_address: '0.0.0.0', port: 5015 })
 end


### PR DESCRIPTION
Hi! This is a draft of input resource.

The resource creates an input if it doesn't exist. If resource's attributes changed, input's configuration changes too.

Examples:
```
# You can create global input
graylog2_input 'global syslog' do
  type 'Syslog TCP' # use name of type instead of type_id
  settings(configuration: { bind_address: '0.0.0.0', port: 514 })
end

# Or for specific node
graylog2_input 'local syslog' do
  hostname 'graylog.local' # use hostname instead of node_id
  type 'Syslog TCP'
  settings(configuration: { bind_address: '0.0.0.0', port: 515 })
end

# Also, you can delete input by :delete action
graylog2_input 'local syslog' do
  action :delete
end
```

What do think about this realization?
If it's okay, I will move most of the ruby logic to the gem and write tests.
