### PR TITLE
Make request_timeout being enabled for GL 2.3 or later

### DIFF
--- a/templates/default/graylog.server.conf.erb
+++ b/templates/default/graylog.server.conf.erb
@@ -83,7 +83,6 @@ elasticsearch_node_data = false
 # Timeouts
 <%= config_option 'elasticsearch_cluster_discovery_timeout', node['graylog2']['elasticsearch']['cluster_discovery_timeout'] -%>
 <%= config_option 'elasticsearch_discovery_initial_state_timeout', node['graylog2']['elasticsearch']['discovery_initial_state_timeout'] -%>
-<%= config_option 'elasticsearch_request_timeout', node['graylog2']['elasticsearch']['request_timeout'] -%>
 <% else -%>
 # Elasticsearch http client (GL >= 2.3)
 <%= config_option 'elasticsearch_connect_timeout', node['graylog2']['elasticsearch']['connect_timeout'] -%>
@@ -121,6 +120,7 @@ elasticsearch_node_data = false
 <%= config_option 'message_journal_segment_size', node['graylog2']['message_journal_segment_size'] -%>
 
 # Timeouts
+<%= config_option 'elasticsearch_request_timeout', node['graylog2']['elasticsearch']['request_timeout'] -%>
 <%= config_option 'output_module_timeout', node['graylog2']['output_module_timeout'] -%>
 <%= config_option 'stale_master_timeout', node['graylog2']['stale_master_timeout'] -%>
 <%= config_option 'shutdown_timeout', node['graylog2']['shutdown_timeout'] -%>


### PR DESCRIPTION
According to the documentation for GL 2.4, elasticsearch_request_timeout should be still available.
http://docs.graylog.org/en/2.4/pages/configuration/server.conf.html#elasticsearch

However, the parameter is being filtered out if major_version <= 2.2 on graylog.server.conf.erb.  The pull request will make the line of the parameter to go out of a criteria by GL version.