### PR TITLE
Add customize data bag item

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@ default['graylog2']['no_retention']              = nil
 default['graylog2']['disable_sigar']             = nil
 default['graylog2']['dashboard_widget_default_cache_time'] = '10s'
 default['graylog2']['secrets_data_bag']                    = 'secrets'
+default['graylog2']['secrets_data_bag_item']               = 'graylog'
 
 # Users
 default['graylog2']['server']['user']  = 'graylog'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,7 +1,7 @@
 # Override attributes from data bag's "server" section
 secrets = {}
 begin
-  secrets = Chef::EncryptedDataBagItem.load(node['graylog2']['secrets_data_bag'], node['graylog2']['secrets_data_bag_item'])['server']
+  secrets = data_bag_item(node['graylog2']['secrets_data_bag'], node['graylog2']['secrets_data_bag_item'])['server']
 rescue
   Chef::Log.debug 'Can not load server secrets from databag'
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,7 +1,7 @@
 # Override attributes from data bag's "server" section
 secrets = {}
 begin
-  secrets = Chef::EncryptedDataBagItem.load(node['graylog2']['secrets_data_bag'], 'graylog')['server']
+  secrets = Chef::EncryptedDataBagItem.load(node['graylog2']['secrets_data_bag'], node['graylog2']['secrets_data_bag_item'])['server']
 rescue
   Chef::Log.debug 'Can not load server secrets from databag'
 end


### PR DESCRIPTION
I have several Graylog instances for the different environments and I want to have one common data bag where i will have several items. This PR introduces the additional option for this and doesn't break compatibility with the previous version.