### PR TITLE
Add support for installing the 'graylog-enterprise-integrations-plugins' package.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,7 @@ node.default['mongodb'] ||= {}
 default['graylog2']['major_version']     = '3.0'
 default['graylog2']['server']['version'] = '3.0.0-11.rc.2'
 default['graylog2']['install_enterprise_plugins']   = true
+default['graylog2']['install_enterprise_integrations_plugins'] = true
 default['graylog2']['install_integrations_plugins'] = true
 
 ## By default the cookbook installs a meta package containing the key and URL for the current Graylog repository. To disable

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -33,6 +33,13 @@ package 'graylog-enterprise-plugins' do
   only_if { node['graylog2']['install_enterprise_plugins'] }
 end
 
+package 'graylog-enterprise-integrations-plugins' do
+  action :install
+  version node['graylog2']['server']['version']
+  notifies :restart, 'service[graylog-server]', node['graylog2']['restart'].to_sym
+  only_if { node['graylog2']['install_enterprise_integrations_plugins'] }
+end
+
 package 'graylog-integrations-plugins' do
   action :install
   version node['graylog2']['server']['version']

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -30,6 +30,10 @@ describe 'graylog2::server' do
       expect(chef_run).to install_package 'graylog-enterprise-plugins'
     end
 
+    it 'installs the graylog-enterprise-integrations-plugins package' do
+      expect(chef_run).to install_package 'graylog-enterprise-integrations-plugins'
+    end
+
     it 'installs the graylog-integrations-plugins  package' do
       expect(chef_run).to install_package 'graylog-integrations-plugins'
     end


### PR DESCRIPTION
We were a bit confused when Scripted Alert Notifications and Forwarder support weren't available, despite the `graylog-enterprise-plugins` package being installed.  We later discovered these are currently in the separate `graylog-enterprise-integrations-plugins` package.

Since `graylog-enterprise-plugins` and `graylog-integrations-plugins` are installed by default, this PR similarly makes installation of the `graylog-enterprise-integrations-plugins` package a default behavior.