### PR TITLE
Allow skip java version check

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -180,6 +180,7 @@ default['graylog2']['server']['log_level_application'] = 'info'
 default['graylog2']['server']['log_level_root']        = 'warn'
 
 # JVM
+default['graylog2']['server']['skip_java_version_check'] = false
 default['graylog2']['server']['java_bin'] = '/usr/bin/java'
 default['graylog2']['server']['java_home'] = ''
 default['graylog2']['server']['java_opts'] = '-Djava.net.preferIPv4Stack=true -Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow'
@@ -199,7 +200,7 @@ default['graylog2']['sidecar']['release']                        = '1'
 default['graylog2']['sidecar']['repository']['version']          = '1'
 default['graylog2']['sidecar']['repository']['release']          = '2'
 default['graylog2']['sidecar']['server_url']                     = 'http://localhost:9000/api'
-default['graylog2']['sidecar']['server_api_token']               = nil 
+default['graylog2']['sidecar']['server_api_token']               = nil
 default['graylog2']['sidecar']['update_interval']                = 10
 default['graylog2']['sidecar']['tls_skip_verify']                = false
 default['graylog2']['sidecar']['send_status']                    = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,22 +1,24 @@
 version = node['graylog2']['major_version']
 
-ohai 'Reload Ohai data' do
-  plugin 'languages'
-  action :reload
-end
+unless node['graylog2']['server']['skip_java_version_check']
+  ohai 'Reload Ohai data' do
+    plugin 'languages'
+    action :reload
+  end
 
-ruby_block 'Check Java version' do
-  block do
-    nil_or_empty = ->(v) { v.nil? || v.empty? }
-    [node['languages'], node['languages']['java'], node['languages']['java']['version']].each { |v|
-      if nil_or_empty.call(v)
-        raise('Java is not installed.')
+  ruby_block 'Check Java version' do
+    block do
+      nil_or_empty = ->(v) { v.nil? || v.empty? }
+      [node['languages'], node['languages']['java'], node['languages']['java']['version']].each { |v|
+        if nil_or_empty.call(v)
+          raise('Java is not installed.')
+        end
+      }
+
+      java_major_version = node['languages']['java']['version'].split('.')[0].to_i
+      if java_major_version < 8 || java_major_version > 11
+        raise('Java version needs to be >= 8 and <= 11')
       end
-    }
-
-    java_major_version = node['languages']['java']['version'].split('.')[0].to_i
-    if java_major_version < 8 || java_major_version > 11
-      raise('Java version needs to be >= 8 and <= 11')
     end
   end
 end


### PR DESCRIPTION
This cookbook should obviously fail if java version provided is not compliant
(<8, >11) but one should be able to get through this security, in case of a uncommon java install.
Ex:
Ohai retrieves the version of oracle java 8 to 1.8 (which is correct), but the check used in the cookbook
does not allow it
Ohai is the worst, it sets its attributes to the highest precedence possible, cf https://docs.chef.io/attribute_precedence/
So, event an node.automatic['languages']['java']['version'] = '11.0.15' before calling the `include_recipe 'graylog2'`,
could not do the trick.

A simple solution is to allow the cookbook user to by pass this security with:
```
node.override['graylog2']['server']['skip_java_version_check'] = true
```

Obviously, this setting is set to false by default.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

